### PR TITLE
Enhance security and watch mode

### DIFF
--- a/src/components/Dashboard.tsx
+++ b/src/components/Dashboard.tsx
@@ -56,7 +56,8 @@ export const Dashboard = () => {
     exportReport,
     setGlobalConfig,
     exportLogs,
-    fetchActivities
+    fetchActivities,
+    getDecryptedApiKey
   } = useDashboardData();
 
   // Auto-refresh activities every 30 seconds
@@ -66,7 +67,7 @@ export const Dashboard = () => {
     logInfo('dashboard', `Setting up auto-refresh for ${repositories.length} repositories`);
     const interval = setInterval(() => {
       logInfo('dashboard', 'Auto-refreshing activities');
-      fetchActivities(repositories, apiKeys);
+      fetchActivities(repositories, apiKeys, getDecryptedApiKey);
     }, 30000);
 
     return () => {
@@ -79,7 +80,7 @@ export const Dashboard = () => {
   useEffect(() => {
     if (repositories.length > 0 && apiKeys.length > 0) {
       logInfo('dashboard', `Initial fetch for ${repositories.length} repositories with ${apiKeys.length} API keys`);
-      fetchActivities(repositories, apiKeys);
+      fetchActivities(repositories, apiKeys, getDecryptedApiKey);
     }
   }, [repositories.length, apiKeys.length]);
 
@@ -113,17 +114,19 @@ export const Dashboard = () => {
 
           <TabsContent value="feed" className="space-y-6 max-w-4xl mx-auto">
             <RealtimeFeed activities={activities} onExportReport={exportReport} isLoading={isLoading} />
-            <WatchMode 
-              repositories={repositories} 
-              apiKeys={apiKeys} 
-              onUpdateRepository={updateRepository}
-            />
+          <WatchMode
+            repositories={repositories}
+            apiKeys={apiKeys}
+            getDecryptedApiKey={getDecryptedApiKey}
+            onUpdateRepository={updateRepository}
+          />
           </TabsContent>
 
           <TabsContent value="repositories" className="space-y-6 max-w-4xl mx-auto">
-            <SelectiveRepositoryLoader 
+            <SelectiveRepositoryLoader
               apiKeys={apiKeys}
               existingRepos={repositories.map(r => `${r.owner}/${r.name}`)}
+              getDecryptedApiKey={getDecryptedApiKey}
               onAddRepository={(repoData) => {
                 addRepository(repoData.name, repoData.owner);
                 // Associate with API key
@@ -184,7 +187,7 @@ export const Dashboard = () => {
           </TabsContent>
 
           <TabsContent value="security" className="space-y-6">
-            <SecurityManagement />
+            <SecurityManagement apiKeys={apiKeys} repositories={repositories} config={globalConfig} />
           </TabsContent>
 
           <TabsContent value="statistics" className="space-y-6">

--- a/src/components/GitHubService.tsx
+++ b/src/components/GitHubService.tsx
@@ -12,10 +12,14 @@ export class GitHubService {
 
   async fetchRepositories(owner: string): Promise<Repository[]> {
     try {
-      const { data } = await this.octokit.rest.repos.listForAuthenticatedUser({
-        type: 'all',
-        per_page: 100,
-      });
+      let data;
+      if (owner) {
+        const res = await this.octokit.rest.repos.listForUser({ username: owner, per_page: 100 });
+        data = res.data;
+      } else {
+        const res = await this.octokit.rest.repos.listForAuthenticatedUser({ type: 'all', per_page: 100 });
+        data = res.data;
+      }
 
       return data.map(repo => ({
         id: repo.id.toString(),

--- a/src/components/WatchMode.tsx
+++ b/src/components/WatchMode.tsx
@@ -24,10 +24,11 @@ import { useLogger } from '@/hooks/useLogger';
 interface WatchModeProps {
   repositories: Repository[];
   apiKeys: any[];
+  getDecryptedApiKey: (id: string) => string | null;
   onUpdateRepository: (repoId: string, updates: Partial<Repository>) => void;
 }
 
-export const WatchMode: React.FC<WatchModeProps> = ({ repositories, apiKeys, onUpdateRepository }) => {
+export const WatchMode: React.FC<WatchModeProps> = ({ repositories, apiKeys, getDecryptedApiKey, onUpdateRepository }) => {
   const { 
     watchModeState, 
     updateWatchedRepos, 
@@ -65,7 +66,12 @@ export const WatchMode: React.FC<WatchModeProps> = ({ repositories, apiKeys, onU
 
     try {
       logInfo('watch-mode', `Fetching data for ${repo.owner}/${repo.name}`);
-      const service = createGitHubService(apiKey.key);
+      const token = getDecryptedApiKey(apiKey.id);
+      if (!token) {
+        logWarn('watch-mode', 'API key locked, skipping fetch', { repo: repo.id });
+        return;
+      }
+      const service = createGitHubService(token);
       
       // Fetch pull requests
       const pullRequests = await service.fetchPullRequests(repo.owner, repo.name);

--- a/src/hooks/useLogger.ts
+++ b/src/hooks/useLogger.ts
@@ -44,6 +44,7 @@ export const useLogger = (logLevel: 'info' | 'warn' | 'error' | 'debug' = 'info'
     };
 
     setLogs(prev => [entry, ...prev].slice(0, 1000)); // Keep only last 1000 logs
+    window.dispatchEvent(new CustomEvent<LogEntry>('log-entry', { detail: entry }));
     
     // Also log to console for debugging
     const consoleMethod = level === 'debug' ? 'log' : level === 'info' ? 'info' : level === 'warn' ? 'warn' : 'error';


### PR DESCRIPTION
## Summary
- gate API keys behind passkey auth
- emit log events to activity feed
- fetch repos using decrypted tokens
- add confirmation for passkey deletion
- compute real security status
- make watch mode use unlocked keys

## Testing
- `npm run build` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_686ed90749e483259bc5971719ffba37