### PR TITLE
Remove log-entry based activity updates

### DIFF
--- a/src/hooks/useActivities.ts
+++ b/src/hooks/useActivities.ts
@@ -1,30 +1,12 @@
-import { useState, useEffect } from 'react';
+import { useState } from 'react';
 import { ActivityItem } from '@/types/dashboard';
 import { useStatsPersistence } from './useStatsPersistence';
 import { createGitHubService } from '@/components/GitHubService';
-import type { LogEntry } from './useLogger';
 
 export const useActivities = () => {
   const [activities, setActivities] = useState<ActivityItem[]>([]);
   const [isLoading, setIsLoading] = useState(false);
   const { mergeStats, updateStats, resetSessionStats } = useStatsPersistence();
-
-  useEffect(() => {
-    const handler = (e: Event) => {
-      const detail = (e as CustomEvent<LogEntry>).detail;
-      const item: ActivityItem = {
-        id: detail.id,
-        type: detail.level === 'error' ? 'failure' : detail.level === 'warn' ? 'alert' : 'success',
-        message: detail.message,
-        repo: detail.category,
-        timestamp: detail.timestamp,
-        details: detail.details
-      };
-      setActivities(prev => [item, ...prev].slice(0, 50));
-    };
-    window.addEventListener('log-entry', handler);
-    return () => window.removeEventListener('log-entry', handler);
-  }, []);
 
   const fetchActivities = async (repositories: any[], apiKeys: any[], getKey: (id: string) => string | null) => {
     if (!repositories.length || !apiKeys.length) {


### PR DESCRIPTION
## Summary
- remove the `log-entry` event listener from `useActivities`
- depend solely on `fetchActivities` for populating activities

## Testing
- `npm run lint` *(fails: unexpected any and other lint errors)*

------
https://chatgpt.com/codex/tasks/task_e_686ee34d549c83259ae119d1b19a9bd1