### PR TITLE
Fetch mergeability status for pull requests

### DIFF
--- a/src/components/GitHubService.tsx
+++ b/src/components/GitHubService.tsx
@@ -53,7 +53,27 @@ export class GitHubService {
         per_page: 100,
       });
 
-      return data;
+      const detailed = await Promise.all(
+        data.map(async pr => {
+          try {
+            const { data: details } = await this.octokit.rest.pulls.get({
+              owner,
+              repo,
+              pull_number: pr.number,
+            });
+
+            return {
+              ...pr,
+              mergeable: details.mergeable,
+              mergeable_state: details.mergeable_state,
+            };
+          } catch {
+            return pr;
+          }
+        })
+      );
+
+      return detailed;
     } catch (error) {
       console.error('Error fetching pull requests:', error);
       throw error;

--- a/src/components/WatchMode.tsx
+++ b/src/components/WatchMode.tsx
@@ -291,6 +291,12 @@ export const WatchMode: React.FC<WatchModeProps> = ({ repositories, apiKeys, get
                                     <span>{pr.user.login}</span>
                                     <span>•</span>
                                     <span>{pr.head.ref} → {pr.base.ref}</span>
+                                    {pr.mergeable_state && (
+                                      <>
+                                        <span>•</span>
+                                        <span className="capitalize">{pr.mergeable_state}</span>
+                                      </>
+                                    )}
                                   </div>
                                 </div>
                               ))


### PR DESCRIPTION
## Summary
- enrich GitHubService.pull listing with mergeable details
- display mergeability state in WatchMode

## Testing
- `npm run lint` *(fails: many existing lint errors)*

------
https://chatgpt.com/codex/tasks/task_e_686ee500c3dc8325886430aabec18a3e