### PR TITLE
Add data-theme on dark mode change

### DIFF
--- a/src/hooks/useGlobalConfig.ts
+++ b/src/hooks/useGlobalConfig.ts
@@ -51,7 +51,9 @@ export const useGlobalConfig = () => {
 
   // Update theme in localStorage when darkMode changes
   useEffect(() => {
-    localStorage.setItem('theme', globalConfig.darkMode ? 'dark' : 'light');
+    const theme = globalConfig.darkMode ? 'dark' : 'light';
+    localStorage.setItem('theme', theme);
+    document.documentElement.setAttribute('data-theme', theme);
     // Apply theme to document
     if (globalConfig.darkMode) {
       document.documentElement.classList.add('dark');


### PR DESCRIPTION
## Summary
- sync `useGlobalConfig` theme behavior with `ThemeToggle`

## Testing
- `npm run lint` *(fails: React hook usage & type errors)*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_686ee8732c608325b3888062dc290eaa