### PR TITLE
Add shadow to StatsCards cards

### DIFF
--- a/src/components/StatsCards.tsx
+++ b/src/components/StatsCards.tsx
@@ -62,7 +62,10 @@ export const StatsCards: React.FC<StatsCardsProps> = ({ repositories, apiKeys, m
   return (
     <div className="grid grid-cols-2 md:grid-cols-3 lg:grid-cols-6 gap-4">
       {stats.map((stat, index) => (
-        <Card key={index} className={`neo-card ${stat.color} p-2`}>
+        <Card
+          key={index}
+          className={`neo-card ${stat.color} p-2 shadow-[4px_4px_0_theme(colors.foreground)]`}
+        >
           <CardHeader className="pb-1">
             <CardTitle className="text-black dark:text-white font-black text-lg text-center">
               {stat.title}
@@ -75,5 +78,4 @@ export const StatsCards: React.FC<StatsCardsProps> = ({ repositories, apiKeys, m
         </Card>
       ))}
     </div>
-  );
-};
+  );};


### PR DESCRIPTION
## Summary
- enhance card appearance in StatsCards by adding shadow class

## Testing
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_686ee879f6c88325a5e9fb60fdda052c