### PR TITLE
Add automerge toggle per repo

### DIFF
--- a/src/components/Dashboard.tsx
+++ b/src/components/Dashboard.tsx
@@ -41,6 +41,7 @@ export const Dashboard = () => {
     logs,
     isLoading,
     toggleRepository,
+    toggleAutoMerge,
     addRepository,
     deleteRepository,
     updateRepository,
@@ -141,6 +142,7 @@ export const Dashboard = () => {
               repositories={repositories}
               apiKeys={apiKeys}
               onToggleRepository={toggleRepository}
+              onToggleAutoMerge={toggleAutoMerge}
               onAddRepository={addRepository}
               onDeleteRepository={deleteRepository}
               onAddBranch={addBranch}

--- a/src/components/RepositoryCard.tsx
+++ b/src/components/RepositoryCard.tsx
@@ -25,6 +25,7 @@ import { Repository, ActivityItem } from '@/types/dashboard';
 interface RepositoryCardProps {
   repo: Repository;
   onToggle: (id: string) => void;
+  onToggleAutoMerge: (id: string) => void;
   onAddBranch: (repoId: string, branch: string) => void;
   onRemoveBranch: (repoId: string, index: number) => void;
   onAddUser: (repoId: string, user: string) => void;
@@ -37,6 +38,7 @@ interface RepositoryCardProps {
 export const RepositoryCard: React.FC<RepositoryCardProps> = ({
   repo,
   onToggle,
+  onToggleAutoMerge,
   onAddBranch,
   onRemoveBranch,
   onAddUser,
@@ -99,7 +101,10 @@ export const RepositoryCard: React.FC<RepositoryCardProps> = ({
               </CardTitle>
               <div className="flex items-center gap-2 mt-1">
                 <Badge variant="secondary" className={`neo-card ${repo.enabled ? 'neo-green' : 'neo-red'} text-black font-bold text-xs`}>
-                  {repo.enabled ? 'Enabled' : 'Disabled'}
+                  {repo.enabled ? 'Active' : 'Inactive'}
+                </Badge>
+                <Badge variant="secondary" className={`neo-card ${repo.autoMergeEnabled ? 'neo-green' : 'neo-red'} text-black font-bold text-xs`}>
+                  {repo.autoMergeEnabled ? 'Automerge On' : 'Automerge Off'}
                 </Badge>
                 <Badge variant="secondary" className="neo-card neo-blue text-black font-bold text-xs">
                   {successRate}% Success
@@ -128,6 +133,11 @@ export const RepositoryCard: React.FC<RepositoryCardProps> = ({
             <Switch
               checked={repo.enabled}
               onCheckedChange={() => onToggle(repo.id)}
+              className="scale-125"
+            />
+            <Switch
+              checked={repo.autoMergeEnabled}
+              onCheckedChange={() => onToggleAutoMerge(repo.id)}
               className="scale-125"
             />
           </div>

--- a/src/components/RepositoryManagement.tsx
+++ b/src/components/RepositoryManagement.tsx
@@ -16,6 +16,7 @@ interface RepositoryManagementProps {
   repositories: Repository[];
   apiKeys: any[];
   onToggleRepository: (id: string) => void;
+  onToggleAutoMerge: (id: string) => void;
   onAddRepository: (name: string, owner: string) => void;
   onDeleteRepository: (id: string) => void;
   onAddBranch: (repoId: string, branch: string) => void;
@@ -29,6 +30,7 @@ export const RepositoryManagement: React.FC<RepositoryManagementProps> = ({
   repositories,
   apiKeys,
   onToggleRepository,
+  onToggleAutoMerge,
   onAddRepository,
   onDeleteRepository,
   onAddBranch,
@@ -190,7 +192,8 @@ export const RepositoryManagement: React.FC<RepositoryManagementProps> = ({
                         {repo.owner}/{repo.name}
                       </CardTitle>
                       <CardDescription className="font-bold">
-                        {repo.enabled ? 'Automerge Enabled' : 'Automerge Disabled'}
+                        {repo.enabled ? 'Active' : 'Inactive'} |
+                        {repo.autoMergeEnabled ? ' Automerge On' : ' Automerge Off'}
                       </CardDescription>
                     </div>
                   </div>
@@ -198,6 +201,11 @@ export const RepositoryManagement: React.FC<RepositoryManagementProps> = ({
                     <Switch
                       checked={repo.enabled}
                       onCheckedChange={() => onToggleRepository(repo.id)}
+                      className="scale-125"
+                    />
+                    <Switch
+                      checked={repo.autoMergeEnabled}
+                      onCheckedChange={() => onToggleAutoMerge(repo.id)}
                       className="scale-125"
                     />
                     <Button

--- a/src/hooks/useDashboardData.ts
+++ b/src/hooks/useDashboardData.ts
@@ -10,6 +10,7 @@ export const useDashboardData = () => {
   const {
     repositories,
     toggleRepository,
+    toggleAutoMerge,
     addRepository,
     deleteRepository,
     updateRepository,
@@ -66,6 +67,7 @@ export const useDashboardData = () => {
     deletedApiKeys,
     isLoading,
     toggleRepository,
+    toggleAutoMerge,
     addRepository,
     deleteRepository,
     updateRepository,

--- a/src/hooks/useRepositories.ts
+++ b/src/hooks/useRepositories.ts
@@ -17,6 +17,7 @@ export const useRepositories = () => {
         // Convert date strings back to Date objects
         return parsed.map((repo: any) => ({
           ...repo,
+          autoMergeEnabled: repo.autoMergeEnabled ?? repo.enabled ?? true,
           lastActivity: repo.lastActivity ? new Date(repo.lastActivity) : undefined,
           recentPull: repo.recentPull ? {
             ...repo.recentPull,
@@ -45,12 +46,29 @@ export const useRepositories = () => {
       repos.map(repo => {
         if (repo.id === id) {
           const newEnabled = !repo.enabled;
-          logInfo('repository', `Repository ${repo.name} ${newEnabled ? 'enabled' : 'disabled'}`, { repo: repo.name, enabled: newEnabled });
-          toast({ 
-            title: `Repository ${repo.name} ${newEnabled ? 'enabled' : 'disabled'}`,
-            description: newEnabled ? 'Auto-merge is now active for this repository' : 'Auto-merge is now inactive for this repository'
+          logInfo('repository', `Repository ${repo.name} ${newEnabled ? 'activated' : 'deactivated'}`, { repo: repo.name, enabled: newEnabled });
+          toast({
+            title: `Repository ${repo.name} ${newEnabled ? 'activated' : 'deactivated'}`,
+            description: newEnabled ? 'Repository is now active' : 'Repository is now inactive'
           });
           return { ...repo, enabled: newEnabled };
+        }
+        return repo;
+      })
+    );
+  };
+
+  const toggleAutoMerge = (id: string) => {
+    setRepositories(repos =>
+      repos.map(repo => {
+        if (repo.id === id) {
+          const newStatus = !repo.autoMergeEnabled;
+          logInfo('repository', `Auto-merge for ${repo.name} ${newStatus ? 'enabled' : 'disabled'}`, { repo: repo.name, autoMergeEnabled: newStatus });
+          toast({
+            title: `Auto-merge ${newStatus ? 'enabled' : 'disabled'} for ${repo.name}`,
+            description: newStatus ? 'Pull requests will be merged automatically' : 'Automatic merging disabled'
+          });
+          return { ...repo, autoMergeEnabled: newStatus };
         }
         return repo;
       })
@@ -73,6 +91,7 @@ export const useRepositories = () => {
       name,
       owner,
       enabled: true,
+      autoMergeEnabled: true,
       allowedBranches: ['codex-*', 'feature/*', 'fix/*'],
       allowedUsers: ['github-actions[bot]'],
       allowAllBranches: false,
@@ -257,6 +276,7 @@ export const useRepositories = () => {
     addRepository,
     deleteRepository,
     updateRepository,
+    toggleAutoMerge,
     addBranch,
     removeBranch,
     addUser,
@@ -264,5 +284,4 @@ export const useRepositories = () => {
     updateRepositoryStats,
     addRepositoryActivity,
     clearAllRepositories
-  };
-};
+  };};

--- a/src/types/dashboard.ts
+++ b/src/types/dashboard.ts
@@ -3,6 +3,7 @@ export interface Repository {
   name: string;
   owner: string;
   enabled: boolean;
+  autoMergeEnabled: boolean;
   allowedBranches: string[];
   allowedUsers: string[];
   allowAllBranches?: boolean;


### PR DESCRIPTION
## Summary
- add `autoMergeEnabled` to Repository type
- extend repositories hook with auto merge toggling
- show separate activation and automerge switches in repository UI

## Testing
- `npm run lint` *(fails: 46 errors)*
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_686eea33af848325ba2c1d451891cdf4