### PR TITLE
Add watch toggle per repository

### DIFF
--- a/src/components/RepositoryManagement.tsx
+++ b/src/components/RepositoryManagement.tsx
@@ -11,6 +11,7 @@ import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@
 import { Collapsible, CollapsibleContent, CollapsibleTrigger } from '@/components/ui/collapsible';
 import { ConfirmationDialog } from '@/components/ui/confirmation-dialog';
 import { EditableList } from '@/components/EditableList';
+import { useWatchModePersistence } from '@/hooks/useWatchModePersistence';
 
 interface RepositoryManagementProps {
   repositories: Repository[];
@@ -45,6 +46,7 @@ export const RepositoryManagement: React.FC<RepositoryManagementProps> = ({
     repoName: '' 
   });
   const { toast } = useToast();
+  const { watchModeState, updateWatchEnabled } = useWatchModePersistence();
 
   const handleAddRepository = () => {
     if (newRepo.name && newRepo.owner) {
@@ -157,6 +159,12 @@ export const RepositoryManagement: React.FC<RepositoryManagementProps> = ({
                       checked={repo.autoMergeEnabled}
                       onCheckedChange={() => onToggleAutoMerge(repo.id)}
                       className="scale-125"
+                    />
+                    <Switch
+                      checked={watchModeState.watchEnabled[repo.id] ?? false}
+                      onCheckedChange={(checked) => updateWatchEnabled(repo.id, checked)}
+                      className="scale-125"
+                      title="Watch"
                     />
                     <Button
                       variant="ghost"

--- a/src/components/WatchMode.tsx
+++ b/src/components/WatchMode.tsx
@@ -3,13 +3,10 @@ import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
 import { Badge } from '@/components/ui/badge';
 import { Button } from '@/components/ui/button';
 import { ScrollArea } from '@/components/ui/scroll-area';
-import { Switch } from '@/components/ui/switch';
-import { Label } from '@/components/ui/label';
 import { 
   Eye, 
-  EyeOff, 
-  GitBranch, 
-  GitPullRequest, 
+  GitBranch,
+  GitPullRequest,
   RefreshCw, 
   Clock,
   AlertCircle,
@@ -29,33 +26,24 @@ interface WatchModeProps {
 }
 
 export const WatchMode: React.FC<WatchModeProps> = ({ repositories, apiKeys, getDecryptedApiKey, onUpdateRepository }) => {
-  const { 
-    watchModeState, 
-    updateWatchedRepos, 
-    updateRepoActivities, 
-    updateRepoPullRequests, 
-    updateLastUpdateTime 
+  const {
+    watchModeState,
+    updateWatchEnabled,
+    updateRepoActivities,
+    updateRepoPullRequests,
+    updateLastUpdateTime
   } = useWatchModePersistence();
   
   const { logInfo, logError, logWarn } = useLogger('info');
   const [isLoading, setIsLoading] = useState(false);
 
-  const watchedRepos = watchModeState.watchedRepos;
+  const watchEnabledMap = watchModeState.watchEnabled;
+  const watchedRepos = Object.keys(watchEnabledMap).filter(id => watchEnabledMap[id]);
   const repoActivities = watchModeState.repoActivities;
   const repoPullRequests = watchModeState.repoPullRequests;
   const lastUpdateTime = watchModeState.lastUpdateTime;
 
   const enabledRepos = repositories.filter(repo => repo.enabled);
-
-  const toggleWatch = (repoId: string) => {
-    const repo = repositories.find(r => r.id === repoId);
-    const newWatchedRepos = watchedRepos.includes(repoId) 
-      ? watchedRepos.filter(id => id !== repoId)
-      : [...watchedRepos, repoId];
-    
-    updateWatchedRepos(newWatchedRepos);
-    logInfo('watch-mode', `${watchedRepos.includes(repoId) ? 'Stopped' : 'Started'} watching ${repo?.owner}/${repo?.name}`);
-  };
 
   const fetchRepoData = async (repo: Repository) => {
     const apiKey = apiKeys.find(key => key.id === repo.apiKeyId && key.isActive);
@@ -159,65 +147,8 @@ export const WatchMode: React.FC<WatchModeProps> = ({ repositories, apiKeys, get
         <CardContent>
           <div className="grid gap-4">
             <div className="text-sm text-muted-foreground">
-              Select repositories to monitor. Watch mode provides real-time updates without any automatic actions.
+              Configure which repositories are watched from the Repositories tab. Watch mode provides real-time updates without automatic actions.
             </div>
-            
-            {enabledRepos.length === 0 ? (
-              <div className="text-center py-8 text-muted-foreground">
-                <GitBranch className="w-12 h-12 mx-auto mb-4 opacity-50" />
-                <p>No enabled repositories</p>
-                <p className="text-sm">Enable repositories in the Repositories tab to start watching</p>
-              </div>
-            ) : (
-              <div className="grid gap-2">
-                {enabledRepos.map(repo => (
-                  <div key={repo.id} className="flex items-center justify-between p-3 rounded border">
-                    <div className="flex items-center gap-3">
-                      <Switch
-                        id={`watch-${repo.id}`}
-                        checked={watchedRepos.includes(repo.id)}
-                        onCheckedChange={() => toggleWatch(repo.id)}
-                      />
-                      <Label htmlFor={`watch-${repo.id}`} className="font-medium">
-                        {repo.owner}/{repo.name}
-                      </Label>
-                    </div>
-                    
-                    {watchedRepos.includes(repo.id) && (
-                      <div className="flex items-center gap-2">
-                        {(() => {
-                          const status = getRepoStatus(repo);
-                          return (
-                            <>
-                              <Badge variant="outline" className="text-xs">
-                                {status.totalPRs} PRs
-                              </Badge>
-                              {status.mergeable > 0 && (
-                                <Badge variant="secondary" className="text-xs neo-green">
-                                  {status.mergeable} mergeable
-                                </Badge>
-                              )}
-                              {status.nonMergeable > 0 && (
-                                <Badge variant="secondary" className="text-xs neo-red">
-                                  {status.nonMergeable} blocked
-                                </Badge>
-                              )}
-                            </>
-                          );
-                        })()}
-                        <Button
-                          onClick={() => window.open(`https://github.com/${repo.owner}/${repo.name}`, '_blank')}
-                          size="sm"
-                          variant="ghost"
-                        >
-                          <ExternalLink className="w-4 h-4" />
-                        </Button>
-                      </div>
-                    )}
-                  </div>
-                ))}
-              </div>
-            )}
           </div>
         </CardContent>
       </Card>

--- a/src/hooks/useRepositories.ts
+++ b/src/hooks/useRepositories.ts
@@ -18,6 +18,7 @@ export const useRepositories = () => {
         return parsed.map((repo: any) => ({
           ...repo,
           autoMergeEnabled: repo.autoMergeEnabled ?? repo.enabled ?? true,
+          watchEnabled: repo.watchEnabled ?? false,
           lastActivity: repo.lastActivity ? new Date(repo.lastActivity) : undefined,
           recentPull: repo.recentPull ? {
             ...repo.recentPull,
@@ -92,6 +93,7 @@ export const useRepositories = () => {
       owner,
       enabled: true,
       autoMergeEnabled: true,
+      watchEnabled: false,
       allowedBranches: ['codex-*', 'feature/*', 'fix/*'],
       allowedUsers: ['github-actions[bot]'],
       allowAllBranches: false,

--- a/src/types/dashboard.ts
+++ b/src/types/dashboard.ts
@@ -4,6 +4,8 @@ export interface Repository {
   owner: string;
   enabled: boolean;
   autoMergeEnabled: boolean;
+  /** Whether this repository should be included in watch mode */
+  watchEnabled?: boolean;
   allowedBranches: string[];
   allowedUsers: string[];
   allowAllBranches?: boolean;


### PR DESCRIPTION
## Summary
- allow persisting watch mode by repo
- add watchEnabled field on `Repository`
- persist watchEnabled state in `useWatchModePersistence`
- expose watch toggle in repository management
- simplify WatchMode UI and rely on repository settings

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_686eef44924883259f5e029f18a81d48