### PR TITLE
Update refresh buttons to brutalist style

### DIFF
--- a/src/components/SelectiveRepositoryLoader.tsx
+++ b/src/components/SelectiveRepositoryLoader.tsx
@@ -239,7 +239,7 @@ export const SelectiveRepositoryLoader: React.FC<SelectiveRepositoryLoaderProps>
           <Button
             onClick={() => selectedApiKey && loadRepositories(selectedApiKey)}
             disabled={!selectedApiKey || isLoading}
-            variant="outline"
+            className="neo-button-secondary"
             size="sm"
           >
             <RefreshCw className={`w-4 h-4 mr-2 ${isLoading ? 'animate-spin' : ''}`} />

--- a/src/components/WatchMode.tsx
+++ b/src/components/WatchMode.tsx
@@ -159,7 +159,7 @@ export const WatchMode: React.FC<WatchModeProps> = ({ repositories, apiKeys, get
                 onClick={refreshAllWatched}
                 disabled={isLoading || watchedRepos.length === 0}
                 size="sm"
-                variant="outline"
+                className="neo-button-secondary"
               >
                 <RefreshCw className={`w-4 h-4 mr-2 ${isLoading ? 'animate-spin' : ''}`} />
                 Refresh


### PR DESCRIPTION
## Summary
- update watch mode refresh button to use brutalist style
- update selective loader refresh button to match brutalist style

## Testing
- `npm test`
- `npm run lint` *(fails: ban-ts-comment etc.)*

------
https://chatgpt.com/codex/tasks/task_e_686ef957d8e883259308340c3974c4c4