### PR TITLE
Add accent color config

### DIFF
--- a/src/components/ConfigSelector.tsx
+++ b/src/components/ConfigSelector.tsx
@@ -10,7 +10,7 @@ interface ConfigSelectorProps {
   value: string | number;
   onChange: (value: string) => void;
   options?: Array<{ value: string; label: string }>;
-  type?: 'select' | 'number';
+  type?: 'select' | 'number' | 'color';
   placeholder?: string;
   min?: number;
   max?: number;
@@ -60,7 +60,7 @@ export const ConfigSelector: React.FC<ConfigSelectorProps> = ({
         ) : (
           <Input
             id={id}
-            type="number"
+            type={type === 'number' ? 'number' : 'color'}
             value={value}
             onChange={(e) => handleChange(e.target.value)}
             className="neo-input"
@@ -71,5 +71,4 @@ export const ConfigSelector: React.FC<ConfigSelectorProps> = ({
         )}
       </div>
     </div>
-  );
-};
+  );};

--- a/src/components/GlobalConfiguration.tsx
+++ b/src/components/GlobalConfiguration.tsx
@@ -512,6 +512,13 @@ export const GlobalConfiguration: React.FC<GlobalConfigurationProps> = ({
               checked={config.darkMode}
               onCheckedChange={(checked) => onConfigChange({ ...config, darkMode: checked })}
             />
+            <ConfigSelector
+              id="accentColor"
+              label="Accent Color"
+              value={config.accentColor}
+              onChange={(value) => onConfigChange({ ...config, accentColor: value })}
+              type="color"
+            />
             <ConfigToggle
               id="hideHeader"
               label="Hide Header"

--- a/src/hooks/useGlobalConfig.ts
+++ b/src/hooks/useGlobalConfig.ts
@@ -1,5 +1,6 @@
 import { useState, useEffect } from 'react';
 import { GlobalConfig } from '@/types/dashboard';
+import { hexToHSL } from '@/lib/utils';
 
 const GLOBAL_CONFIG_STORAGE_KEY = 'automerger-global-config';
 
@@ -19,6 +20,7 @@ const getDefaultConfig = (): GlobalConfig => ({
   serverCheckInterval: 30000, // 30 seconds
   logLevel: 'info',
   darkMode: localStorage.getItem('theme') !== 'light',
+  accentColor: '#313135',
   customCss: '',
   customJs: '',
   feedActions: [],
@@ -61,6 +63,13 @@ export const useGlobalConfig = () => {
       document.documentElement.classList.remove('dark');
     }
   }, [globalConfig.darkMode]);
+
+  // Update accent color
+  useEffect(() => {
+    const hsl = hexToHSL(globalConfig.accentColor);
+    document.documentElement.style.setProperty('--accent', hsl);
+    document.documentElement.style.setProperty('--sidebar-accent', hsl);
+  }, [globalConfig.accentColor]);
 
   const updateConfig = (updates: Partial<GlobalConfig>) => {
     setGlobalConfig(prev => ({ ...prev, ...updates }));

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -4,3 +4,38 @@ import { twMerge } from "tailwind-merge"
 export function cn(...inputs: ClassValue[]) {
   return twMerge(clsx(inputs))
 }
+
+export function hexToHSL(hex: string): string {
+  let hHex = hex.replace('#', '')
+  if (hHex.length === 3) {
+    hHex = hHex.split('').map((x) => x + x).join('')
+  }
+  const r = parseInt(hHex.slice(0, 2), 16) / 255
+  const g = parseInt(hHex.slice(2, 4), 16) / 255
+  const b = parseInt(hHex.slice(4, 6), 16) / 255
+
+  const max = Math.max(r, g, b)
+  const min = Math.min(r, g, b)
+  let h = 0
+  let s = 0
+  const l = (max + min) / 2
+
+  if (max !== min) {
+    const d = max - min
+    s = l > 0.5 ? d / (2 - max - min) : d / (max + min)
+    switch (max) {
+      case r:
+        h = (g - b) / d + (g < b ? 6 : 0)
+        break
+      case g:
+        h = (b - r) / d + 2
+        break
+      case b:
+        h = (r - g) / d + 4
+        break
+    }
+    h *= 60
+  }
+
+  return `${Math.round(h)} ${Math.round(s * 100)}% ${Math.round(l * 100)}%`
+}

--- a/src/types/dashboard.ts
+++ b/src/types/dashboard.ts
@@ -144,11 +144,11 @@ export interface GlobalConfig {
   serverCheckInterval: number;
   logLevel: 'info' | 'warn' | 'error' | 'debug';
   darkMode: boolean;
+  accentColor: string;
   customCss: string;
   customJs: string;
   feedActions: FeedAction[];
   statsPeriod: StatsPeriod;
   webhooks: Webhook[];
   hideHeader: boolean;
-  logsDisabled: boolean;
-}
+  logsDisabled: boolean;}


### PR DESCRIPTION
## Summary
- extend global config with `accentColor`
- expose accent color selector in GlobalConfiguration UI
- update global config hook to apply accent color via CSS variables
- add `hexToHSL` converter helper
- support color input in ConfigSelector

## Testing
- `npm run lint` *(fails: @typescript-eslint/no-explicit-any, react-hooks, etc.)*
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_686ef96904f88325a7bad5ab63d50a2f