### PR TITLE
Fix watch mode GitHub polling

### DIFF
--- a/src/components/WatchMode.tsx
+++ b/src/components/WatchMode.tsx
@@ -112,11 +112,11 @@ export const WatchMode: React.FC<WatchModeProps> = ({ repositories, apiKeys, get
     logInfo('watch-mode', 'Completed refresh of all watched repositories');
   };
 
-  // Auto-refresh every 5 seconds
+  // Auto-refresh every 30 seconds to avoid spamming the GitHub API
   useEffect(() => {
     if (watchedRepos.length === 0) return;
 
-    const interval = setInterval(refreshAllWatched, 5000);
+    const interval = setInterval(refreshAllWatched, 30000);
     return () => clearInterval(interval);
   }, [watchedRepos, enabledRepos]);
 


### PR DESCRIPTION
## Summary
- avoid spamming the GitHub API by reducing watch mode polling to 30s

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_686efe36788c8325844f9949bb932c13