### PR TITLE
Fix export button style in RealtimeFeed

### DIFF
--- a/src/components/RealtimeFeed.tsx
+++ b/src/components/RealtimeFeed.tsx
@@ -43,7 +43,7 @@ export const RealtimeFeed: React.FC<RealtimeFeedProps> = ({ activities, onExport
             <Activity className="w-5 h-5" />
             Recent Activity
           </CardTitle>
-          <Button onClick={onExportReport} variant="outline" size="sm">
+          <Button onClick={onExportReport} size="sm" className="neo-button-secondary">
             <Download className="w-4 h-4 mr-2" />
             Export Report
           </Button>


### PR DESCRIPTION
## Summary
- use `neo-button-secondary` class for the export button in RealtimeFeed

## Testing
- `bun run test` *(fails: ReferenceError: Cannot access 'dispose' before initialization)*

------
https://chatgpt.com/codex/tasks/task_e_686f031123cc832586268f18428cf4e3