### PR TITLE
Stop polling when keys locked

### DIFF
--- a/src/components/Dashboard.tsx
+++ b/src/components/Dashboard.tsx
@@ -34,6 +34,7 @@ export const Dashboard = () => {
   const {
     repositories,
     apiKeys,
+    isUnlocked,
     showApiKey,
     globalConfig,
     activities,
@@ -63,7 +64,7 @@ export const Dashboard = () => {
 
   // Auto-refresh activities every 5 seconds
   useEffect(() => {
-    if (repositories.length === 0 || apiKeys.length === 0) return;
+    if (repositories.length === 0 || apiKeys.length === 0 || !isUnlocked) return;
 
     logInfo('dashboard', `Setting up auto-refresh for ${repositories.length} repositories`);
     const interval = setInterval(() => {
@@ -75,15 +76,15 @@ export const Dashboard = () => {
       logInfo('dashboard', 'Clearing auto-refresh interval');
       clearInterval(interval);
     };
-  }, [repositories.length, apiKeys.length]);
+  }, [repositories.length, apiKeys.length, isUnlocked]);
 
   // Initial fetch when repos or keys change
   useEffect(() => {
-    if (repositories.length > 0 && apiKeys.length > 0) {
+    if (repositories.length > 0 && apiKeys.length > 0 && isUnlocked) {
       logInfo('dashboard', `Initial fetch for ${repositories.length} repositories with ${apiKeys.length} API keys`);
       fetchActivities(repositories, apiKeys, getDecryptedApiKey);
     }
-  }, [repositories.length, apiKeys.length]);
+  }, [repositories.length, apiKeys.length, isUnlocked]);
 
   // Log app initialization
   useEffect(() => {
@@ -119,6 +120,7 @@ export const Dashboard = () => {
             repositories={repositories}
             apiKeys={apiKeys}
             getDecryptedApiKey={getDecryptedApiKey}
+            isUnlocked={isUnlocked}
             onUpdateRepository={updateRepository}
           />
           </TabsContent>

--- a/src/components/WatchMode.tsx
+++ b/src/components/WatchMode.tsx
@@ -24,10 +24,11 @@ interface WatchModeProps {
   repositories: Repository[];
   apiKeys: ApiKey[];
   getDecryptedApiKey: (id: string) => string | null;
+  isUnlocked: boolean;
   onUpdateRepository: (repoId: string, updates: Partial<Repository>) => void;
 }
 
-export const WatchMode: React.FC<WatchModeProps> = ({ repositories, apiKeys, getDecryptedApiKey, onUpdateRepository }) => {
+export const WatchMode: React.FC<WatchModeProps> = ({ repositories, apiKeys, getDecryptedApiKey, isUnlocked, onUpdateRepository }) => {
   const {
     watchModeState,
     updateWatchEnabled,
@@ -106,7 +107,7 @@ export const WatchMode: React.FC<WatchModeProps> = ({ repositories, apiKeys, get
   };
 
   const refreshAllWatched = async () => {
-    if (isLoading) return;
+    if (isLoading || !isUnlocked) return;
     const watchedReposList = enabledRepos.filter(repo => watchedRepos.includes(repo.id));
     if (watchedReposList.length === 0) return;
 
@@ -123,18 +124,18 @@ export const WatchMode: React.FC<WatchModeProps> = ({ repositories, apiKeys, get
 
   // Auto-refresh every 30 seconds to avoid spamming the GitHub API
   useEffect(() => {
-    if (watchedRepos.length === 0) return;
+    if (watchedRepos.length === 0 || !isUnlocked) return;
 
     const interval = setInterval(refreshAllWatched, 30000);
     return () => clearInterval(interval);
-  }, [watchedRepos, enabledRepos]);
+  }, [watchedRepos, enabledRepos, isUnlocked]);
 
   // Initial load for watched repos
   useEffect(() => {
-    if (watchedRepos.length > 0) {
+    if (watchedRepos.length > 0 && isUnlocked) {
       refreshAllWatched();
     }
-  }, [watchedRepos]);
+  }, [watchedRepos, isUnlocked]);
 
   const getRepoStatus = (repo: Repository) => {
     const pullRequests = repoPullRequests[repo.id] || [];

--- a/src/hooks/useDashboardData.ts
+++ b/src/hooks/useDashboardData.ts
@@ -25,6 +25,7 @@ export const useDashboardData = () => {
 
   const {
     apiKeys,
+    isUnlocked,
     showApiKey,
     deletedApiKeys,
     addApiKey,
@@ -59,6 +60,7 @@ export const useDashboardData = () => {
   return {
     repositories,
     apiKeys,
+    isUnlocked,
     showApiKey,
     globalConfig,
     activities,


### PR DESCRIPTION
## Summary
- expose `isUnlocked` from `useDashboardData`
- stop dashboard's stats refresh if API keys are locked
- disable watch mode polling while API keys are locked

## Testing
- `bun run lint` *(fails: 43 errors, 17 warnings)*
- `bun test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_686f04cd98a08325a6bf812c1ad45210