### PR TITLE
Display API key lock notice

### DIFF
--- a/src/components/ApiKeyManagement.tsx
+++ b/src/components/ApiKeyManagement.tsx
@@ -2,12 +2,14 @@ import React, { useState } from 'react';
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
 import { Button } from '@/components/ui/button';
 import { Input } from '@/components/ui/input';
-import { Plus } from 'lucide-react';
+import { Plus, AlertCircle } from 'lucide-react';
+import { Alert, AlertTitle, AlertDescription } from '@/components/ui/alert';
 import { ApiKey } from '@/types/dashboard';
 import { ApiKeyCard } from '@/components/ApiKeyCard';
 
 interface ApiKeyManagementProps {
   apiKeys: ApiKey[];
+  isUnlocked: boolean;
   onAddApiKey: (name: string, key: string) => void;
   onToggleApiKey: (id: string) => void;
   onDeleteApiKey: (id: string) => void;
@@ -18,6 +20,7 @@ interface ApiKeyManagementProps {
 
 export const ApiKeyManagement: React.FC<ApiKeyManagementProps> = ({
   apiKeys,
+  isUnlocked,
   onAddApiKey,
   onToggleApiKey,
   onDeleteApiKey,
@@ -36,6 +39,15 @@ export const ApiKeyManagement: React.FC<ApiKeyManagementProps> = ({
 
   return (
     <div className="space-y-6">
+      {!isUnlocked && (
+        <Alert variant="destructive" className="neo-card">
+          <AlertCircle className="w-4 h-4" />
+          <AlertTitle>API Keys Locked</AlertTitle>
+          <AlertDescription>
+            API keys are locked until authentication is complete.
+          </AlertDescription>
+        </Alert>
+      )}
       {/* Add API Key */}
       <Card className="neo-card">
         <CardHeader>

--- a/src/components/Dashboard.tsx
+++ b/src/components/Dashboard.tsx
@@ -153,15 +153,16 @@ export const Dashboard = () => {
           </TabsContent>
 
           <TabsContent value="api-keys" className="space-y-6">
-            <ApiKeyManagement
-              apiKeys={apiKeys}
-              onAddApiKey={addApiKey}
-              onToggleApiKey={toggleApiKey}
-              onDeleteApiKey={deleteApiKey}
-              onRevertDelete={revertApiKeyDeletion}
-              showApiKey={showApiKey}
-              onToggleShowApiKey={toggleShowApiKey}
-            />
+          <ApiKeyManagement
+            apiKeys={apiKeys}
+            isUnlocked={isUnlocked}
+            onAddApiKey={addApiKey}
+            onToggleApiKey={toggleApiKey}
+            onDeleteApiKey={deleteApiKey}
+            onRevertDelete={revertApiKeyDeletion}
+            showApiKey={showApiKey}
+            onToggleShowApiKey={toggleShowApiKey}
+          />
           </TabsContent>
 
           <TabsContent value="actions" className="space-y-6 max-w-4xl mx-auto">

--- a/src/hooks/useDashboardData.ts
+++ b/src/hooks/useDashboardData.ts
@@ -25,6 +25,7 @@ export const useDashboardData = () => {
 
   const {
     apiKeys,
+    isUnlocked,
     showApiKey,
     deletedApiKeys,
     addApiKey,
@@ -59,6 +60,7 @@ export const useDashboardData = () => {
   return {
     repositories,
     apiKeys,
+    isUnlocked,
     showApiKey,
     globalConfig,
     activities,


### PR DESCRIPTION
## Summary
- show an alert in API Key Management when keys are still locked
- pass new `isUnlocked` flag through dashboard hooks

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_686f061628708325921179706a24f3a8