### PR TITLE
Add passkey restrictions and locked warning

### DIFF
--- a/src/components/Dashboard.tsx
+++ b/src/components/Dashboard.tsx
@@ -12,6 +12,7 @@ import { FeedActions } from '@/components/FeedActions';
 import { useDashboardData } from '@/hooks/useDashboardData';
 import { ConnectionManager } from '@/components/ConnectionManager';
 import { LogsTab } from '@/components/LogsTab';
+import { Dialog, DialogContent, DialogHeader, DialogTitle } from '@/components/ui/dialog';
 import { 
   Shield, 
   GitBranch, 
@@ -58,7 +59,9 @@ export const Dashboard = () => {
     setGlobalConfig,
     exportLogs,
     fetchActivities,
-    getDecryptedApiKey
+    getDecryptedApiKey,
+    showLockedModal,
+    setShowLockedModal
   } = useDashboardData();
 
   // Auto-refresh activities every 5 seconds
@@ -95,6 +98,14 @@ export const Dashboard = () => {
 
   return (
     <div className="min-h-screen bg-background p-6">
+      <Dialog open={showLockedModal} onOpenChange={setShowLockedModal}>
+        <DialogContent className="neo-card">
+          <DialogHeader>
+            <DialogTitle>API Keys Locked</DialogTitle>
+          </DialogHeader>
+          <p className="text-sm">Authenticate with your passkey to unlock API keys.</p>
+        </DialogContent>
+      </Dialog>
       <div className="max-w-7xl mx-auto space-y-8">
         {/* Header */}
         {!globalConfig.hideHeader && <DashboardHeader apiKeys={apiKeys} />}

--- a/src/components/SecurityManagement.tsx
+++ b/src/components/SecurityManagement.tsx
@@ -232,9 +232,9 @@ export const SecurityManagement: React.FC<SecurityManagementProps> = ({ apiKeys,
               )}
               <Dialog open={showPasskeyDialog} onOpenChange={setShowPasskeyDialog}>
                 <DialogTrigger asChild>
-                  <Button 
-                    className="neo-button bg-black text-white w-full" 
-                    disabled={!passkeySupported}
+                  <Button
+                    className="neo-button bg-black text-white w-full"
+                    disabled={!passkeySupported || credentials.length >= 1}
                   >
                     <Plus className="w-4 h-4 mr-2" />
                     {credentials.length > 0 ? 'Add Passkey' : 'Setup Passkey'}
@@ -266,7 +266,7 @@ export const SecurityManagement: React.FC<SecurityManagementProps> = ({ apiKeys,
                 <p className="text-xs font-bold">Registered Passkeys:</p>
                 {credentials.map((cred) => (
                   <div key={cred.id} className="flex items-center justify-between bg-white/20 p-2 rounded">
-                    <span className="text-xs font-bold truncate">{cred.id.slice(0, 8)}...</span>
+                    <span className="text-xs font-bold truncate">{cred.label ?? `${cred.id.slice(0, 8)}...`}</span>
                     <Button
                       size="sm"
                       variant="destructive"

--- a/src/hooks/useApiKeys.ts
+++ b/src/hooks/useApiKeys.ts
@@ -1,4 +1,4 @@
-import { useState, useEffect } from 'react';
+import { useState, useEffect, useRef } from 'react';
 import { ApiKey } from '@/types/dashboard';
 import { useToast } from './use-toast';
 import { useLogger } from './useLogger';
@@ -34,6 +34,8 @@ export const useApiKeys = () => {
 
   const [unlocked, setUnlocked] = useState(false);
   const [decryptedKeys, setDecryptedKeys] = useState<Record<string, string>>({});
+  const [showLockedModal, setShowLockedModal] = useState(false);
+  const lockedShownRef = useRef(false);
 
   // Persist API keys to localStorage whenever they change
   useEffect(() => {
@@ -66,9 +68,17 @@ export const useApiKeys = () => {
           logInfo('api-key', 'API keys unlocked');
         } else {
           logInfo('api-key', 'Passkey authentication failed', { error: result.error });
+          if (!lockedShownRef.current) {
+            setShowLockedModal(true);
+            lockedShownRef.current = true;
+          }
         }
       } catch (error) {
         logInfo('api-key', 'Error unlocking API keys', error);
+        if (!lockedShownRef.current) {
+          setShowLockedModal(true);
+          lockedShownRef.current = true;
+        }
       }
     };
 
@@ -262,6 +272,8 @@ export const useApiKeys = () => {
   return {
     apiKeys,
     isUnlocked: unlocked,
+    showLockedModal,
+    setShowLockedModal,
     showApiKey,
     deletedApiKeys,
     addApiKey,

--- a/src/hooks/useDashboardData.ts
+++ b/src/hooks/useDashboardData.ts
@@ -35,7 +35,9 @@ export const useDashboardData = () => {
     updateApiKeyConnectionStatus,
     getDecryptedApiKey,
     refreshApiKeyStatus,
-    clearAllApiKeys
+    clearAllApiKeys,
+    showLockedModal,
+    setShowLockedModal
   } = useApiKeys();
 
   const {
@@ -95,6 +97,8 @@ export const useDashboardData = () => {
     resetSessionStats,
     exportLogs,
     clearAllRepositories,
-    clearAllApiKeys
+    clearAllApiKeys,
+    showLockedModal,
+    setShowLockedModal
   };
 };

--- a/src/utils/passkeyAuth.ts
+++ b/src/utils/passkeyAuth.ts
@@ -3,6 +3,7 @@ export interface PasskeyCredential {
   publicKey: string;
   counter: number;
   created: Date;
+  label: string;
   lastUsed?: Date;
 }
 
@@ -37,6 +38,11 @@ export class PasskeyService {
     }
 
     try {
+      const storedCredentials = this.getStoredCredentials();
+      if (storedCredentials.length > 0) {
+        return { success: false, error: 'A passkey is already registered' };
+      }
+
       const challenge = new Uint8Array(32);
       crypto.getRandomValues(challenge);
 
@@ -82,10 +88,10 @@ export class PasskeyService {
         publicKey: this.arrayBufferToBase64(response.getPublicKey()!),
         counter: 0,
         created: new Date(),
+        label: username,
       };
 
       // Store credential in localStorage (in production, use secure server storage)
-      const storedCredentials = this.getStoredCredentials();
       storedCredentials.push(passkeyCredential);
       localStorage.setItem('passkey_credentials', JSON.stringify(storedCredentials));
 


### PR DESCRIPTION
## Summary
- limit passkey registration to a single credential
- store a user supplied label with each passkey
- disable passkey registration button when one exists and show label
- warn once with a modal when API keys remain locked

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_686f05d667788325b0e84cc969095202