### PR TITLE
Add refresh interval config and style fixes

### DIFF
--- a/src/components/Dashboard.tsx
+++ b/src/components/Dashboard.tsx
@@ -68,7 +68,7 @@ export const Dashboard = () => {
     setShowLockedModal
   } = useDashboardData();
 
-  // Auto-refresh activities every 5 seconds
+  // Auto-refresh activities based on configured interval
   useEffect(() => {
     if (repositories.length === 0 || apiKeys.length === 0 || !isUnlocked) return;
 
@@ -76,13 +76,13 @@ export const Dashboard = () => {
     const interval = setInterval(() => {
       logInfo('dashboard', 'Auto-refreshing activities');
       fetchActivities(repositories, apiKeys, getDecryptedApiKey);
-    }, 5000);
+    }, globalConfig.refreshInterval);
 
     return () => {
       logInfo('dashboard', 'Clearing auto-refresh interval');
       clearInterval(interval);
     };
-  }, [repositories.length, apiKeys.length, isUnlocked]);
+  }, [repositories.length, apiKeys.length, isUnlocked, globalConfig.refreshInterval]);
 
   // Initial fetch when repos or keys change
   useEffect(() => {

--- a/src/components/GlobalConfiguration.tsx
+++ b/src/components/GlobalConfiguration.tsx
@@ -489,6 +489,15 @@ export const GlobalConfiguration: React.FC<GlobalConfigurationProps> = ({
               max={300}
             />
             <ConfigSelector
+              id="refreshInterval"
+              label="Activity Refresh Interval (seconds)"
+              value={config.refreshInterval / 1000}
+              onChange={(value) => onConfigChange({ ...config, refreshInterval: parseInt(value) * 1000 })}
+              type="number"
+              min={1}
+              max={300}
+            />
+            <ConfigSelector
               id="logLevel"
               label="Log Level"
               value={config.logLevel}

--- a/src/components/WatchMode.tsx
+++ b/src/components/WatchMode.tsx
@@ -366,7 +366,7 @@ export const WatchMode: React.FC<WatchModeProps> = ({ repositories, apiKeys, get
                                     <Button
                                       onClick={() => handleClose(repo, pr.number)}
                                       size="sm"
-                                      variant="destructive"
+                                      className="neo-button neo-red"
                                     >
                                       <XCircle className="w-3 h-3 mr-1" />
                                       Close

--- a/src/hooks/useGlobalConfig.ts
+++ b/src/hooks/useGlobalConfig.ts
@@ -17,6 +17,7 @@ const getDefaultConfig = (): GlobalConfig => ({
   allowAllUsers: false,
   fetchMode: 'github-api',
   serverCheckInterval: 30000, // 30 seconds
+  refreshInterval: 5000,
   logLevel: 'info',
   darkMode: localStorage.getItem('theme') !== 'light',
   accentColor: '#313135',
@@ -68,6 +69,7 @@ export const useGlobalConfig = () => {
     const hsl = hexToHSL(globalConfig.accentColor);
     document.documentElement.style.setProperty('--accent', hsl);
     document.documentElement.style.setProperty('--sidebar-accent', hsl);
+    document.documentElement.style.setProperty('--primary', hsl);
   }, [globalConfig.accentColor]);
 
   const updateConfig = (updates: Partial<GlobalConfig>) => {

--- a/src/index.css
+++ b/src/index.css
@@ -128,10 +128,14 @@
   }
   
   .neo-button-secondary {
-    @apply bg-secondary border-4 border-foreground shadow-[4px_4px_0px_0px_theme(colors.foreground)] 
-           hover:shadow-[2px_2px_0px_0px_theme(colors.foreground)] 
-           hover:translate-x-[2px] hover:translate-y-[2px] 
+    @apply bg-secondary border-4 border-foreground shadow-[4px_4px_0px_0px_theme(colors.foreground)]
+           hover:shadow-[2px_2px_0px_0px_theme(colors.foreground)]
+           hover:translate-x-[2px] hover:translate-y-[2px]
            transition-all duration-150 font-black uppercase tracking-wider;
+  }
+
+  .neo-button.neo-red {
+    @apply bg-[hsl(var(--neo-red))] text-white;
   }
   
   .neo-input {

--- a/src/types/dashboard.ts
+++ b/src/types/dashboard.ts
@@ -154,4 +154,6 @@ export interface GlobalConfig {
   statsPeriod: StatsPeriod;
   webhooks: Webhook[];
   hideHeader: boolean;
-  logsDisabled: boolean;}
+  logsDisabled: boolean;
+  refreshInterval: number;
+}


### PR DESCRIPTION
## Summary
- make the dashboard refresh interval configurable in GlobalConfig
- persist the new setting and apply accent colour to primary buttons
- style the Close PR button in brutualism

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_686f107463e483259928f8565855d964