### PR TITLE
Add brutalist feed entries and color dropdown

### DIFF
--- a/src/components/Dashboard.tsx
+++ b/src/components/Dashboard.tsx
@@ -75,7 +75,7 @@ export const Dashboard = () => {
     logInfo('dashboard', `Setting up auto-refresh for ${repositories.length} repositories`);
     const interval = setInterval(() => {
       logInfo('dashboard', 'Auto-refreshing activities');
-      fetchActivities(repositories, apiKeys, getDecryptedApiKey);
+      fetchActivities(repositories, apiKeys, getDecryptedApiKey, addRepositoryActivity);
     }, globalConfig.refreshInterval);
 
     return () => {
@@ -88,7 +88,7 @@ export const Dashboard = () => {
   useEffect(() => {
     if (repositories.length > 0 && apiKeys.length > 0 && isUnlocked) {
       logInfo('dashboard', `Initial fetch for ${repositories.length} repositories with ${apiKeys.length} API keys`);
-      fetchActivities(repositories, apiKeys, getDecryptedApiKey);
+      fetchActivities(repositories, apiKeys, getDecryptedApiKey, addRepositoryActivity);
     }
   }, [repositories.length, apiKeys.length, isUnlocked]);
 

--- a/src/components/GlobalConfiguration.tsx
+++ b/src/components/GlobalConfiguration.tsx
@@ -53,6 +53,19 @@ export const GlobalConfiguration: React.FC<GlobalConfigurationProps> = ({
   const { toast } = useToast();
   const { logInfo, logError, logWarn } = useLogger('info');
 
+  const accentColorOptions = [
+    { value: '#000000', label: 'Black' },
+    { value: '#1a1a1a', label: 'Dark Grey' },
+    { value: '#d3d3d3', label: 'Light Grey' },
+    { value: '#ffffff', label: 'White' },
+    { value: '#ff0000', label: 'Red' },
+    { value: '#ffa500', label: 'Orange' },
+    { value: '#ffff00', label: 'Yellow' },
+    { value: '#008000', label: 'Green' },
+    { value: '#0000ff', label: 'Blue' },
+    { value: '#800080', label: 'Purple' }
+  ];
+
   const addBranchPattern = () => {
     if (newPattern) {
       onConfigChange({
@@ -532,13 +545,27 @@ export const GlobalConfiguration: React.FC<GlobalConfigurationProps> = ({
               checked={config.darkMode}
               onCheckedChange={(checked) => onConfigChange({ ...config, darkMode: checked })}
             />
-            <ConfigSelector
-              id="accentColor"
-              label="Accent Color"
-              value={config.accentColor}
-              onChange={(value) => onConfigChange({ ...config, accentColor: value })}
-              type="color"
-            />
+            <div className="grid grid-cols-2 items-center gap-4">
+              <Label htmlFor="accentColor" className="font-bold">Accent Color</Label>
+              <Select
+                value={config.accentColor}
+                onValueChange={(value) => onConfigChange({ ...config, accentColor: value })}
+              >
+                <SelectTrigger className="neo-input">
+                  <SelectValue />
+                </SelectTrigger>
+                <SelectContent>
+                  {accentColorOptions.map((option) => (
+                    <SelectItem key={option.value} value={option.value}>
+                      <div className="flex items-center gap-2">
+                        <span className="w-4 h-4 border border-foreground" style={{ backgroundColor: option.value }} />
+                        {option.label}
+                      </div>
+                    </SelectItem>
+                  ))}
+                </SelectContent>
+              </Select>
+            </div>
             <ConfigToggle
               id="hideHeader"
               label="Hide Header"

--- a/src/components/RealtimeFeed.tsx
+++ b/src/components/RealtimeFeed.tsx
@@ -60,7 +60,7 @@ export const RealtimeFeed: React.FC<RealtimeFeedProps> = ({ activities, onExport
                 </div>
               ) : (
                 activities.map((activity) => (
-                  <div key={activity.id} className="flex items-center gap-3 p-3 rounded neo-card">
+                  <div key={activity.id} className="flex items-center gap-3 p-3 neo-card">
                     <div className={`neo-card p-2 ${getActivityColor(activity.type)}`}>
                       {getActivityIcon(activity.type)}
                     </div>
@@ -69,7 +69,7 @@ export const RealtimeFeed: React.FC<RealtimeFeedProps> = ({ activities, onExport
                       <p className="text-sm text-muted-foreground">{activity.repo}</p>
                     </div>
                     <div className="flex items-center gap-2">
-                      <Badge variant="outline" className="text-xs">
+                      <Badge variant="outline" className="text-xs neo-card rounded-none">
                         {new Date(activity.timestamp).toLocaleString()}
                       </Badge>
                       <Button


### PR DESCRIPTION
## Summary
- fix recent activity fetch so repo events are recorded per repository
- make activity feed entries and timestamp badges brutalist
- add preset accent color options including grayscale colors

## Testing
- `npm test`
- `npm run lint` *(fails: 43 errors, 17 warnings)*

------
https://chatgpt.com/codex/tasks/task_e_686f1ace93b083259b5d7d7dd0c2de31