### PR TITLE
Improve repo ordering and passkey UX

### DIFF
--- a/src/components/AuthOverlay.tsx
+++ b/src/components/AuthOverlay.tsx
@@ -1,0 +1,24 @@
+import React, { useEffect, useState } from 'react';
+
+export const AuthOverlay: React.FC = () => {
+  const [active, setActive] = useState(false);
+
+  useEffect(() => {
+    const start = () => setActive(true);
+    const end = () => setActive(false);
+    window.addEventListener('passkey-auth-start', start);
+    window.addEventListener('passkey-auth-end', end);
+    return () => {
+      window.removeEventListener('passkey-auth-start', start);
+      window.removeEventListener('passkey-auth-end', end);
+    };
+  }, []);
+
+  if (!active) return null;
+
+  return (
+    <div className="fixed inset-0 z-50 flex items-center justify-center bg-background/80 neo-card font-black text-xl">
+      Waiting for authentication...
+    </div>
+  );
+};

--- a/src/components/Dashboard.tsx
+++ b/src/components/Dashboard.tsx
@@ -12,6 +12,7 @@ import { FeedActions } from '@/components/FeedActions';
 import { useDashboardData } from '@/hooks/useDashboardData';
 import { ConnectionManager } from '@/components/ConnectionManager';
 import { LogsTab } from '@/components/LogsTab';
+import { AuthOverlay } from '@/components/AuthOverlay';
 import { Dialog, DialogContent, DialogHeader, DialogTitle } from '@/components/ui/dialog';
 import { 
   Shield, 
@@ -102,6 +103,7 @@ export const Dashboard = () => {
 
   return (
     <div className="min-h-screen bg-background p-6">
+      <AuthOverlay />
       <Dialog open={showLockedModal} onOpenChange={setShowLockedModal}>
         <DialogContent className="neo-card">
           <DialogHeader>
@@ -170,6 +172,7 @@ export const Dashboard = () => {
               onRemoveBranch={removeBranch}
               onAddUser={addUser}
               onRemoveUser={removeUser}
+              onMoveRepository={reorderRepository}
             />
           </TabsContent>
 

--- a/src/components/RepositoryManagement.tsx
+++ b/src/components/RepositoryManagement.tsx
@@ -4,7 +4,7 @@ import { Button } from '@/components/ui/button';
 import { Input } from '@/components/ui/input';
 import { Switch } from '@/components/ui/switch';
 import { Badge } from '@/components/ui/badge';
-import { Plus, Github, GitBranch, Users, Key, Webhook, Shield, Trash2, ChevronDown, ChevronRight } from 'lucide-react';
+import { Plus, Github, GitBranch, Users, Key, Webhook, Shield, Trash2, ChevronDown, ChevronRight, ArrowUp, ArrowDown } from 'lucide-react';
 import { Repository } from '@/types/dashboard';
 import { useToast } from '@/hooks/use-toast';
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@/components/ui/select';
@@ -27,6 +27,7 @@ interface RepositoryManagementProps {
   onRemoveBranch: (repoId: string, branchIndex: number) => void;
   onAddUser: (repoId: string, user: string) => void;
   onRemoveUser: (repoId: string, userIndex: number) => void;
+  onMoveRepository: (from: number, to: number) => void;
 }
 
 export const RepositoryManagement: React.FC<RepositoryManagementProps> = ({
@@ -42,7 +43,8 @@ export const RepositoryManagement: React.FC<RepositoryManagementProps> = ({
   onAddBranch,
   onRemoveBranch,
   onAddUser,
-  onRemoveUser
+  onRemoveUser,
+  onMoveRepository
 }) => {
   const [newRepo, setNewRepo] = useState({ name: '', owner: '', branch: '', user: '' });
   const [collapsedRepos, setCollapsedRepos] = useState<Set<string>>(new Set(repositories.map(r => r.id)));
@@ -135,7 +137,7 @@ export const RepositoryManagement: React.FC<RepositoryManagementProps> = ({
 
       {/* Repository List */}
       <div className="grid gap-6">
-        {repositories.map((repo) => (
+        {repositories.map((repo, index) => (
           <Collapsible key={repo.id} open={!collapsedRepos.has(repo.id)}>
             <Card className="neo-card">
               <CardHeader>
@@ -160,6 +162,24 @@ export const RepositoryManagement: React.FC<RepositoryManagementProps> = ({
                       onCheckedChange={() => onToggleRepository(repo.id)}
                       className="scale-125"
                     />
+                    <Button
+                      variant="ghost"
+                      size="sm"
+                      onClick={() => onMoveRepository(index, Math.max(0, index - 1))}
+                      className="p-2"
+                      title="Move Up"
+                    >
+                      <ArrowUp className="w-4 h-4" />
+                    </Button>
+                    <Button
+                      variant="ghost"
+                      size="sm"
+                      onClick={() => onMoveRepository(index, Math.min(repositories.length - 1, index + 1))}
+                      className="p-2"
+                      title="Move Down"
+                    >
+                      <ArrowDown className="w-4 h-4" />
+                    </Button>
                     <Button
                       variant="ghost"
                       size="sm"

--- a/src/components/WatchMode.tsx
+++ b/src/components/WatchMode.tsx
@@ -14,7 +14,9 @@ import {
   ExternalLink,
   GitMerge,
   XCircle,
-  Trash2
+  Trash2,
+  ArrowUp,
+  ArrowDown
 } from 'lucide-react';
 import { Repository, ActivityItem, ApiKey } from '@/types/dashboard';
 import { createGitHubService } from '@/components/GitHubService';
@@ -45,7 +47,8 @@ export const WatchMode: React.FC<WatchModeProps> = ({ repositories, apiKeys, get
     updateRepoPullRequests,
     updateRepoStrayBranches,
     updateLastUpdateTime,
-    updateRepoLastFetched
+    updateRepoLastFetched,
+    reorderRepoActivity
   } = useWatchModePersistence();
   
   const { logInfo, logError, logWarn, logDebug } = useLogger('info');
@@ -450,12 +453,34 @@ export const WatchMode: React.FC<WatchModeProps> = ({ repositories, apiKeys, get
                                 <p className="text-sm">No recent activity</p>
                               </div>
                             ) : (
-                              activities.slice(0, 20).map(activity => (
-                                <div key={activity.id} className="p-3 border rounded">
-                                  <p className="text-sm font-medium mb-1">{activity.message}</p>
-                                  <p className="text-xs text-muted-foreground">
-                                    {new Date(activity.timestamp).toLocaleString()}
-                                  </p>
+                              activities.slice(0, 20).map((activity, idx) => (
+                                <div key={activity.id} className="p-3 border rounded flex items-start justify-between gap-2">
+                                  <div>
+                                    <p className="text-sm font-medium mb-1">{activity.message}</p>
+                                    <p className="text-xs text-muted-foreground">
+                                      {new Date(activity.timestamp).toLocaleString()}
+                                    </p>
+                                  </div>
+                                  <div className="flex flex-col gap-1">
+                                    <Button
+                                      variant="ghost"
+                                      size="sm"
+                                      className="p-1"
+                                      onClick={() => reorderRepoActivity(repo.id, idx, Math.max(0, idx - 1))}
+                                      title="Move Up"
+                                    >
+                                      <ArrowUp className="w-3 h-3" />
+                                    </Button>
+                                    <Button
+                                      variant="ghost"
+                                      size="sm"
+                                      className="p-1"
+                                      onClick={() => reorderRepoActivity(repo.id, idx, Math.min(activities.length - 1, idx + 1))}
+                                      title="Move Down"
+                                    >
+                                      <ArrowDown className="w-3 h-3" />
+                                    </Button>
+                                  </div>
                                 </div>
                               ))
                             )}

--- a/src/components/ui/select.tsx
+++ b/src/components/ui/select.tsx
@@ -17,7 +17,7 @@ const SelectTrigger = React.forwardRef<
   <SelectPrimitive.Trigger
     ref={ref}
     className={cn(
-      "flex h-10 w-full items-center justify-between rounded-md border border-input bg-background px-3 py-2 text-sm ring-offset-background placeholder:text-muted-foreground focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50 [&>span]:line-clamp-1",
+      "neo-input flex h-10 w-full items-center justify-between px-3 py-2 [&>span]:line-clamp-1",
       className
     )}
     {...props}

--- a/src/hooks/useApiKeys.ts
+++ b/src/hooks/useApiKeys.ts
@@ -65,6 +65,8 @@ export const useApiKeys = () => {
           });
           setDecryptedKeys(map);
           setUnlocked(true);
+          setShowLockedModal(false);
+          lockedShownRef.current = false;
           logInfo('api-key', 'API keys unlocked');
         } else {
           logInfo('api-key', 'Passkey authentication failed', { error: result.error });

--- a/src/hooks/useDashboardData.ts
+++ b/src/hooks/useDashboardData.ts
@@ -23,6 +23,7 @@ export const useDashboardData = () => {
     removeUser,
     updateRepositoryStats,
     addRepositoryActivity,
+    reorderRepository,
     clearAllRepositories
   } = useRepositories();
 
@@ -105,6 +106,7 @@ export const useDashboardData = () => {
     resetSessionStats,
     exportLogs,
     clearAllRepositories,
+    reorderRepository,
     clearAllApiKeys,
     showLockedModal,
     setShowLockedModal

--- a/src/hooks/useRepositories.ts
+++ b/src/hooks/useRepositories.ts
@@ -103,6 +103,23 @@ export const useRepositories = () => {
     );
   };
 
+  const reorderRepository = (fromIndex: number, toIndex: number) => {
+    setRepositories(repos => {
+      const updated = [...repos];
+      if (
+        fromIndex < 0 ||
+        fromIndex >= updated.length ||
+        toIndex < 0 ||
+        toIndex >= updated.length
+      ) {
+        return updated;
+      }
+      const [moved] = updated.splice(fromIndex, 1);
+      updated.splice(toIndex, 0, moved);
+      return updated;
+    });
+  };
+
   const addRepository = (name: string, owner: string, apiKeyId?: string) => {
     const existingRepo = repositories.find(r => r.name === name && r.owner === owner);
     if (existingRepo) {
@@ -318,5 +335,6 @@ export const useRepositories = () => {
     removeUser,
     updateRepositoryStats,
     addRepositoryActivity,
+    reorderRepository,
     clearAllRepositories
   };};

--- a/src/hooks/useWatchModePersistence.ts
+++ b/src/hooks/useWatchModePersistence.ts
@@ -71,6 +71,27 @@ export const useWatchModePersistence = () => {
     }));
   };
 
+  const reorderRepoActivity = (repoId: string, from: number, to: number) => {
+    setWatchModeState(prev => {
+      const list = prev.repoActivities[repoId] || [];
+      const updated = [...list];
+      if (
+        from < 0 ||
+        from >= updated.length ||
+        to < 0 ||
+        to >= updated.length
+      ) {
+        return prev;
+      }
+      const [m] = updated.splice(from, 1);
+      updated.splice(to, 0, m);
+      return {
+        ...prev,
+        repoActivities: { ...prev.repoActivities, [repoId]: updated }
+      };
+    });
+  };
+
   const updateRepoPullRequests = (repoId: string, prs: unknown[]) => {
     setWatchModeState(prev => ({
       ...prev,
@@ -102,6 +123,7 @@ export const useWatchModePersistence = () => {
     updateRepoPullRequests,
     updateRepoStrayBranches,
     updateLastUpdateTime,
-    updateRepoLastFetched
+    updateRepoLastFetched,
+    reorderRepoActivity
   };
 };

--- a/src/utils/passkeyAuth.ts
+++ b/src/utils/passkeyAuth.ts
@@ -120,6 +120,7 @@ export class PasskeyService {
 
     try {
       this.isAuthenticating = true;
+      window.dispatchEvent(new Event('passkey-auth-start'));
       const storedCredentials = this.getStoredCredentials();
       
       if (storedCredentials.length === 0) {
@@ -164,6 +165,7 @@ export class PasskeyService {
       return { success: false, error: 'Authentication failed' };
     } finally {
       this.isAuthenticating = false;
+      window.dispatchEvent(new Event('passkey-auth-end'));
     }
   }
 


### PR DESCRIPTION
## Summary
- allow reordering repositories
- support activity reordering in Watch Mode
- show waiting overlay when requesting passkey
- style dropdowns using brutalist theme
- hide locked dialog once authentication succeeds

## Testing
- `npm run lint` *(fails: Unexpected any and other errors)*
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_686f241d4b088325b47790c5642c6e1c