### PR TITLE
Fix auth overlay and reorderable lists

### DIFF
--- a/src/components/Dashboard.tsx
+++ b/src/components/Dashboard.tsx
@@ -64,6 +64,8 @@ export const Dashboard = () => {
     exportLogs,
     fetchActivities,
     getDecryptedApiKey,
+    unlock,
+    authInProgress,
     showLockedModal,
     setShowLockedModal
   } = useDashboardData();
@@ -102,6 +104,11 @@ export const Dashboard = () => {
 
   return (
     <div className="min-h-screen bg-background p-6">
+      {authInProgress && (
+        <div className="fixed inset-0 bg-background/80 flex items-center justify-center z-50 neo-card font-black text-xl">
+          Waiting for authentication...
+        </div>
+      )}
       <Dialog open={showLockedModal} onOpenChange={setShowLockedModal}>
         <DialogContent className="neo-card">
           <DialogHeader>
@@ -207,7 +214,12 @@ export const Dashboard = () => {
           </TabsContent>
 
           <TabsContent value="security" className="space-y-6">
-            <SecurityManagement apiKeys={apiKeys} repositories={repositories} config={globalConfig} />
+            <SecurityManagement
+              apiKeys={apiKeys}
+              repositories={repositories}
+              config={globalConfig}
+              onAuthenticate={unlock}
+            />
           </TabsContent>
 
           <TabsContent value="statistics" className="space-y-6">

--- a/src/components/EditableList.tsx
+++ b/src/components/EditableList.tsx
@@ -2,24 +2,34 @@ import React, { useState } from 'react';
 import { Button } from '@/components/ui/button';
 import { Input } from '@/components/ui/input';
 import { Badge } from '@/components/ui/badge';
-import { Plus, Edit2, Check, X } from 'lucide-react';
+import { Plus, Edit2, Check, X, ChevronUp, ChevronDown } from 'lucide-react';
 
 interface EditableListProps {
   items: string[];
   onItemsChange: (items: string[]) => void;
   placeholder: string;
   itemColor?: string;
+  reorderable?: boolean;
 }
 
 export const EditableList: React.FC<EditableListProps> = ({
   items,
   onItemsChange,
   placeholder,
-  itemColor = 'neo-blue'
+  itemColor = 'neo-blue',
+  reorderable = false
 }) => {
   const [newItem, setNewItem] = useState('');
   const [editingIndex, setEditingIndex] = useState<number | null>(null);
   const [editValue, setEditValue] = useState('');
+
+  const moveItem = (from: number, to: number) => {
+    if (to < 0 || to >= items.length) return;
+    const updated = [...items];
+    const [moved] = updated.splice(from, 1);
+    updated.splice(to, 0, moved);
+    onItemsChange(updated);
+  };
 
   const addItem = () => {
     if (newItem.trim()) {
@@ -84,8 +94,8 @@ export const EditableList: React.FC<EditableListProps> = ({
             ) : (
               <>
                 <div className="flex-1">
-                  <Badge 
-                    variant="secondary" 
+                  <Badge
+                    variant="secondary"
                     className={`neo-card ${itemColor} text-black dark:text-white font-bold cursor-pointer hover:opacity-80`}
                     onClick={() => startEditing(index)}
                   >
@@ -93,6 +103,26 @@ export const EditableList: React.FC<EditableListProps> = ({
                     {item}
                   </Badge>
                 </div>
+                {reorderable && (
+                  <>
+                    <Button
+                      onClick={() => moveItem(index, index - 1)}
+                      size="sm"
+                      variant="ghost"
+                      className="text-foreground"
+                    >
+                      <ChevronUp className="w-4 h-4" />
+                    </Button>
+                    <Button
+                      onClick={() => moveItem(index, index + 1)}
+                      size="sm"
+                      variant="ghost"
+                      className="text-foreground"
+                    >
+                      <ChevronDown className="w-4 h-4" />
+                    </Button>
+                  </>
+                )}
                 <Button
                   onClick={() => removeItem(index)}
                   size="sm"

--- a/src/components/GlobalConfiguration.tsx
+++ b/src/components/GlobalConfiguration.tsx
@@ -390,6 +390,7 @@ export const GlobalConfiguration: React.FC<GlobalConfigurationProps> = ({
           <h4 className="font-black text-lg">Default Branch Patterns</h4>
           <EditableList
             items={config.defaultBranchPatterns}
+            reorderable
             onItemsChange={(items) => onConfigChange({ ...config, defaultBranchPatterns: items })}
             placeholder="e.g., codex-*"
             itemColor="neo-blue"
@@ -401,6 +402,7 @@ export const GlobalConfiguration: React.FC<GlobalConfigurationProps> = ({
           <h4 className="font-black text-lg">Default Allowed Users</h4>
           <EditableList
             items={config.defaultAllowedUsers}
+            reorderable
             onItemsChange={(items) => onConfigChange({ ...config, defaultAllowedUsers: items })}
             placeholder="e.g., github-actions[bot]"
             itemColor="neo-green"
@@ -412,6 +414,7 @@ export const GlobalConfiguration: React.FC<GlobalConfigurationProps> = ({
           <h4 className="font-black text-lg">Protected Branches</h4>
           <EditableList
             items={config.protectedBranches}
+            reorderable
             onItemsChange={(items) => onConfigChange({ ...config, protectedBranches: items })}
             placeholder="e.g., main"
             itemColor="neo-red"

--- a/src/components/RepositoryManagement.tsx
+++ b/src/components/RepositoryManagement.tsx
@@ -197,6 +197,7 @@ export const RepositoryManagement: React.FC<RepositoryManagementProps> = ({
                       </h4>
                        <EditableList
                          items={repo.allowedBranches}
+                         reorderable
                          onItemsChange={(items) => {
                            // Update branch patterns for this repository
                            const updatedBranches = items;
@@ -212,6 +213,7 @@ export const RepositoryManagement: React.FC<RepositoryManagementProps> = ({
                        </h4>
                        <EditableList
                          items={repo.protectedBranches || []}
+                         reorderable
                          onItemsChange={(items) => {
                            const updatedBranches = items;
                            console.log('Update protected branches for repo:', repo.id, updatedBranches);
@@ -235,6 +237,7 @@ export const RepositoryManagement: React.FC<RepositoryManagementProps> = ({
                       </h4>
                        <EditableList
                          items={repo.allowedUsers}
+                         reorderable
                          onItemsChange={(items) => {
                            // Update allowed users for this repository
                            const updatedUsers = items;

--- a/src/components/SecurityManagement.tsx
+++ b/src/components/SecurityManagement.tsx
@@ -18,9 +18,10 @@ interface SecurityManagementProps {
   apiKeys: ApiKey[];
   repositories: Repository[];
   config: GlobalConfig;
+  onAuthenticate: () => void;
 }
 
-export const SecurityManagement: React.FC<SecurityManagementProps> = ({ apiKeys, repositories, config }) => {
+export const SecurityManagement: React.FC<SecurityManagementProps> = ({ apiKeys, repositories, config, onAuthenticate }) => {
   const [passkeySupported, setPasskeySupported] = useState(false);
   const [credentials, setCredentials] = useState<PasskeyCredential[]>([]);
   const [webhooks, setWebhooks] = useState<WebhookConfig[]>([]);
@@ -67,12 +68,7 @@ export const SecurityManagement: React.FC<SecurityManagementProps> = ({ apiKeys,
   };
 
   const handleAuthenticatePasskey = async () => {
-    const result = await PasskeyService.authenticate();
-    if (result.success) {
-      toast({ title: "Authentication successful!" });
-    } else {
-      toast({ title: "Authentication failed", description: result.error, variant: "destructive" });
-    }
+    await onAuthenticate();
   };
 
   const handleRemoveCredential = async () => {

--- a/src/components/WatchMode.tsx
+++ b/src/components/WatchMode.tsx
@@ -14,7 +14,9 @@ import {
   ExternalLink,
   GitMerge,
   XCircle,
-  Trash2
+  Trash2,
+  ChevronUp,
+  ChevronDown
 } from 'lucide-react';
 import { Repository, ActivityItem, ApiKey } from '@/types/dashboard';
 import { createGitHubService } from '@/components/GitHubService';
@@ -45,7 +47,8 @@ export const WatchMode: React.FC<WatchModeProps> = ({ repositories, apiKeys, get
     updateRepoPullRequests,
     updateRepoStrayBranches,
     updateLastUpdateTime,
-    updateRepoLastFetched
+    updateRepoLastFetched,
+    reorderRepoActivity
   } = useWatchModePersistence();
   
   const { logInfo, logError, logWarn, logDebug } = useLogger('info');
@@ -450,12 +453,32 @@ export const WatchMode: React.FC<WatchModeProps> = ({ repositories, apiKeys, get
                                 <p className="text-sm">No recent activity</p>
                               </div>
                             ) : (
-                              activities.slice(0, 20).map(activity => (
-                                <div key={activity.id} className="p-3 border rounded">
-                                  <p className="text-sm font-medium mb-1">{activity.message}</p>
-                                  <p className="text-xs text-muted-foreground">
-                                    {new Date(activity.timestamp).toLocaleString()}
-                                  </p>
+                              activities.slice(0, 20).map((activity, idx) => (
+                                <div key={activity.id} className="p-3 border rounded flex items-start gap-2">
+                                  <div className="flex-1">
+                                    <p className="text-sm font-medium mb-1">{activity.message}</p>
+                                    <p className="text-xs text-muted-foreground">
+                                      {new Date(activity.timestamp).toLocaleString()}
+                                    </p>
+                                  </div>
+                                  <div className="flex flex-col">
+                                    <Button
+                                      variant="ghost"
+                                      size="sm"
+                                      onClick={() => reorderRepoActivity(repo.id, idx, idx - 1)}
+                                      className="text-foreground"
+                                    >
+                                      <ChevronUp className="w-4 h-4" />
+                                    </Button>
+                                    <Button
+                                      variant="ghost"
+                                      size="sm"
+                                      onClick={() => reorderRepoActivity(repo.id, idx, idx + 1)}
+                                      className="text-foreground"
+                                    >
+                                      <ChevronDown className="w-4 h-4" />
+                                    </Button>
+                                  </div>
                                 </div>
                               ))
                             )}

--- a/src/components/ui/dropdown-menu.tsx
+++ b/src/components/ui/dropdown-menu.tsx
@@ -63,7 +63,7 @@ const DropdownMenuContent = React.forwardRef<
       ref={ref}
       sideOffset={sideOffset}
       className={cn(
-        "z-50 min-w-[8rem] overflow-hidden rounded-md border bg-popover p-1 text-popover-foreground shadow-md data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2",
+        "neo-card z-50 min-w-[8rem] overflow-hidden bg-popover p-1 text-popover-foreground data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2",
         className
       )}
       {...props}

--- a/src/components/ui/select.tsx
+++ b/src/components/ui/select.tsx
@@ -73,7 +73,7 @@ const SelectContent = React.forwardRef<
     <SelectPrimitive.Content
       ref={ref}
       className={cn(
-        "relative z-50 max-h-96 min-w-[8rem] overflow-hidden rounded-md border bg-popover text-popover-foreground shadow-md data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2",
+        "neo-card relative z-50 max-h-96 min-w-[8rem] overflow-hidden bg-popover text-popover-foreground data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2",
         position === "popper" &&
           "data-[side=bottom]:translate-y-1 data-[side=left]:-translate-x-1 data-[side=right]:translate-x-1 data-[side=top]:-translate-y-1",
         className

--- a/src/hooks/useDashboardData.ts
+++ b/src/hooks/useDashboardData.ts
@@ -30,6 +30,7 @@ export const useDashboardData = () => {
     apiKeys,
     isUnlocked,
     showApiKey,
+    authInProgress,
     deletedApiKeys,
     addApiKey,
     toggleApiKey,
@@ -40,6 +41,7 @@ export const useDashboardData = () => {
     getDecryptedApiKey,
     refreshApiKeyStatus,
     clearAllApiKeys,
+    unlock,
     showLockedModal,
     setShowLockedModal
   } = useApiKeys();
@@ -106,6 +108,8 @@ export const useDashboardData = () => {
     exportLogs,
     clearAllRepositories,
     clearAllApiKeys,
+    unlock,
+    authInProgress,
     showLockedModal,
     setShowLockedModal
   };

--- a/src/hooks/useWatchModePersistence.ts
+++ b/src/hooks/useWatchModePersistence.ts
@@ -71,6 +71,19 @@ export const useWatchModePersistence = () => {
     }));
   };
 
+  const reorderRepoActivity = (repoId: string, from: number, to: number) => {
+    setWatchModeState(prev => {
+      const list = [...(prev.repoActivities[repoId] || [])];
+      if (from < 0 || from >= list.length || to < 0 || to >= list.length) return prev;
+      const [moved] = list.splice(from, 1);
+      list.splice(to, 0, moved);
+      return {
+        ...prev,
+        repoActivities: { ...prev.repoActivities, [repoId]: list }
+      };
+    });
+  };
+
   const updateRepoPullRequests = (repoId: string, prs: unknown[]) => {
     setWatchModeState(prev => ({
       ...prev,
@@ -102,6 +115,7 @@ export const useWatchModePersistence = () => {
     updateRepoPullRequests,
     updateRepoStrayBranches,
     updateLastUpdateTime,
-    updateRepoLastFetched
+    updateRepoLastFetched,
+    reorderRepoActivity
   };
 };


### PR DESCRIPTION
## Summary
- add optional reordering to `EditableList`
- style dropdowns with brutalist look
- allow reordering of activities in watch mode
- show authentication progress overlay and expose unlock function
- close modal after unlocking

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_686f241d4b088325b47790c5642c6e1c