### PR TITLE
Fix blank screen after OAuth

### DIFF
--- a/vite.config.ts
+++ b/vite.config.ts
@@ -5,6 +5,7 @@ import { componentTagger } from "lovable-tagger";
 
 // https://vitejs.dev/config/
 export default defineConfig(({ mode }) => ({
+  base: "./",
   server: {
     host: "::",
     port: 8080,


### PR DESCRIPTION
## Summary
- set Vite `base` option so built assets load correctly when the app is served from a subdirectory

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_686f27e157f48325839626390ee21f2d