### PR TITLE
Fix OAuth redirect blank screen

### DIFF
--- a/src/main.tsx
+++ b/src/main.tsx
@@ -3,6 +3,13 @@ import App from './App.tsx'
 import { Toaster } from '@/components/ui/toaster'
 import './index.css'
 
+// GitHub OAuth callbacks add ?code= and ?state= parameters which can break
+// relative asset paths when the page reloads. Clean up the URL so the app
+// loads correctly after authentication.
+if (window.location.search.includes('code=')) {
+  window.history.replaceState({}, '', window.location.pathname)
+}
+
 createRoot(document.getElementById("root")!).render(
   <>
     <App />


### PR DESCRIPTION
## Summary
- strip OAuth params from URL before bootstrapping app

## Testing
- `npm run lint` *(fails: 43 errors)*
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_686f2a1b9a9c83258197636e837b8101