### PR TITLE
Handle localStorage quota error gracefully

### DIFF
--- a/src/hooks/useRepositories.ts
+++ b/src/hooks/useRepositories.ts
@@ -42,7 +42,23 @@ export const useRepositories = () => {
 
   // Persist repositories to localStorage whenever they change
   useEffect(() => {
-    localStorage.setItem(REPOSITORIES_STORAGE_KEY, JSON.stringify(repositories));
+    try {
+      localStorage.setItem(
+        REPOSITORIES_STORAGE_KEY,
+        JSON.stringify(repositories)
+      );
+    } catch (error) {
+      if (error instanceof DOMException && error.name === 'QuotaExceededError') {
+        console.error('Storage quota exceeded while saving repositories');
+        toast({
+          title: 'Storage limit reached',
+          description: 'Unable to save repository data to localStorage.',
+          variant: 'destructive'
+        });
+      } else {
+        console.error('Error saving repositories:', error);
+      }
+    }
   }, [repositories]);
 
   const toggleRepository = (id: string) => {


### PR DESCRIPTION
## Summary
- prevent crashing if localStorage quota is exceeded

## Testing
- `npm test`
- `npm run lint` *(fails: unexpected any)*

------
https://chatgpt.com/codex/tasks/task_e_686f30df47f48325a2842d17300bc438