### PR TITLE
Limit persisted watch mode entries

### DIFF
--- a/src/hooks/useWatchModePersistence.ts
+++ b/src/hooks/useWatchModePersistence.ts
@@ -1,6 +1,9 @@
 import { useState, useEffect } from 'react';
 
 const WATCH_MODE_STORAGE_KEY = 'automerger-watch-mode';
+// Maximum number of items persisted per repository history list.
+// Older entries are trimmed before being saved to localStorage.
+const MAX_ITEMS = 50;
 
 export interface WatchModeState {
   lastUpdateTime: Date;
@@ -65,9 +68,10 @@ export const useWatchModePersistence = () => {
   }, [watchModeState]);
 
   const updateRepoActivities = (repoId: string, activities: unknown[]) => {
+    const trimmed = activities.slice(-MAX_ITEMS);
     setWatchModeState(prev => ({
       ...prev,
-      repoActivities: { ...prev.repoActivities, [repoId]: activities }
+      repoActivities: { ...prev.repoActivities, [repoId]: trimmed }
     }));
   };
 
@@ -85,16 +89,18 @@ export const useWatchModePersistence = () => {
   };
 
   const updateRepoPullRequests = (repoId: string, prs: unknown[]) => {
+    const trimmed = prs.slice(-MAX_ITEMS);
     setWatchModeState(prev => ({
       ...prev,
-      repoPullRequests: { ...prev.repoPullRequests, [repoId]: prs }
+      repoPullRequests: { ...prev.repoPullRequests, [repoId]: trimmed }
     }));
   };
 
   const updateRepoStrayBranches = (repoId: string, branches: string[]) => {
+    const trimmed = branches.slice(-MAX_ITEMS);
     setWatchModeState(prev => ({
       ...prev,
-      repoStrayBranches: { ...prev.repoStrayBranches, [repoId]: branches }
+      repoStrayBranches: { ...prev.repoStrayBranches, [repoId]: trimmed }
     }));
   };
 


### PR DESCRIPTION
## Summary
- limit how many repo history items are kept in watch-mode persistence

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_686f3327c8788325bebdbb12b1307e82