### PR TITLE
Add clear logs feature

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,3 +71,7 @@ Yes, you can!
 To connect a domain, navigate to Project > Settings > Domains and click Connect Domain.
 
 Read more here: [Setting up a custom domain](https://docs.lovable.dev/tips-tricks/custom-domain#step-by-step-guide)
+
+## Activity Logs
+
+The dashboard keeps a running history of actions in the **Logs** tab. You can download this history using **Export Logs** or remove it entirely using the new **Clear Logs** button next to the export option.

--- a/src/components/Dashboard.tsx
+++ b/src/components/Dashboard.tsx
@@ -63,6 +63,7 @@ export const Dashboard = () => {
     exportReport,
     setGlobalConfig,
     exportLogs,
+    clearLogs,
     fetchActivities,
     getDecryptedApiKey,
     unlock,
@@ -244,7 +245,7 @@ export const Dashboard = () => {
 
           <TabsContent value="logs" className="space-y-6">
             {!globalConfig.logsDisabled ? (
-              <LogsTab logs={logs} onExportLogs={exportLogs} />
+              <LogsTab logs={logs} onExportLogs={exportLogs} onClearLogs={clearLogs} />
             ) : (
               <div className="text-center py-8 text-muted-foreground">
                 <FileText className="w-12 h-12 mx-auto mb-4 opacity-50" />

--- a/src/components/LogsTab.tsx
+++ b/src/components/LogsTab.tsx
@@ -2,7 +2,7 @@ import React, { useState } from 'react';
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card';
 import { Button } from '@/components/ui/button';
 import { Badge } from '@/components/ui/badge';
-import { Download, FileText, Search, Filter } from 'lucide-react';
+import { Download, FileText, Search, Filter, Trash2 } from 'lucide-react';
 import { Input } from '@/components/ui/input';
 import { useToast } from '@/hooks/use-toast';
 
@@ -18,9 +18,10 @@ interface LogEntry {
 interface LogsTabProps {
   logs: LogEntry[];
   onExportLogs: () => void;
+  onClearLogs: () => void;
 }
 
-export const LogsTab: React.FC<LogsTabProps> = ({ logs, onExportLogs }) => {
+export const LogsTab: React.FC<LogsTabProps> = ({ logs, onExportLogs, onClearLogs }) => {
   const [searchTerm, setSearchTerm] = useState('');
   const [levelFilter, setLevelFilter] = useState<string>('all');
   const { toast } = useToast();
@@ -35,6 +36,11 @@ export const LogsTab: React.FC<LogsTabProps> = ({ logs, onExportLogs }) => {
   const handleExportLogs = () => {
     onExportLogs();
     toast({ title: "Logs exported successfully!" });
+  };
+
+  const handleClearLogs = () => {
+    onClearLogs();
+    toast({ title: "Logs cleared" });
   };
 
   const getLevelColor = (level: string) => {
@@ -62,10 +68,16 @@ export const LogsTab: React.FC<LogsTabProps> = ({ logs, onExportLogs }) => {
                 Track all system actions and events
               </CardDescription>
             </div>
-            <Button onClick={handleExportLogs} className="neo-button">
-              <Download className="w-4 h-4 mr-2" />
-              Export Logs
-            </Button>
+            <div className="flex gap-2">
+              <Button onClick={handleExportLogs} className="neo-button">
+                <Download className="w-4 h-4 mr-2" />
+                Export Logs
+              </Button>
+              <Button onClick={handleClearLogs} variant="outline" className="neo-button-secondary">
+                <Trash2 className="w-4 h-4 mr-2" />
+                Clear Logs
+              </Button>
+            </div>
           </div>
         </CardHeader>
         <CardContent className="space-y-4">

--- a/src/hooks/useDashboardData.ts
+++ b/src/hooks/useDashboardData.ts
@@ -5,7 +5,7 @@ import { useActivities } from './useActivities';
 import { useLogger } from './useLogger';
 
 export const useDashboardData = () => {
-  const { logs, exportLogs } = useLogger();
+  const { logs, exportLogs, clearLogs } = useLogger();
   
   const {
     repositories,
@@ -106,6 +106,7 @@ export const useDashboardData = () => {
     updateStats,
     resetSessionStats,
     exportLogs,
+    clearLogs,
     clearAllRepositories,
     clearAllApiKeys,
     unlock,


### PR DESCRIPTION
## Summary
- add `clearLogs` to `useDashboardData`
- expose `onClearLogs` prop on `LogsTab` and display a button for it
- pass `clearLogs` from Dashboard to LogsTab
- document log clearing in README

## Testing
- `npm test`
- `npm run lint` *(fails: several lint errors)*

------
https://chatgpt.com/codex/tasks/task_e_686f3332ef588325b5d21c76f63275a0