### PR TITLE
Add watch mode cleanup and limit storage

### DIFF
--- a/src/components/GlobalConfiguration.tsx
+++ b/src/components/GlobalConfiguration.tsx
@@ -18,6 +18,7 @@ import { ConfigToggle } from '@/components/ConfigToggle';
 import { ConfigSelector } from '@/components/ConfigSelector';
 import { EditableList } from '@/components/EditableList';
 import { useLogger } from '@/hooks/useLogger';
+import { useWatchModePersistence } from '@/hooks/useWatchModePersistence';
 
 interface GlobalConfigurationProps {
   config: GlobalConfig;
@@ -52,6 +53,7 @@ export const GlobalConfiguration: React.FC<GlobalConfigurationProps> = ({
   const [importFile, setImportFile] = useState<File | null>(null);
   const { toast } = useToast();
   const { logInfo, logError, logWarn } = useLogger('info');
+  const { clearWatchModeState } = useWatchModePersistence();
 
   const accentColorOptions = [
     { value: '#000000', label: 'Black' },
@@ -581,6 +583,19 @@ export const GlobalConfiguration: React.FC<GlobalConfigurationProps> = ({
               checked={config.logsDisabled}
               onCheckedChange={(checked) => onConfigChange({ ...config, logsDisabled: checked })}
             />
+            <div className="flex justify-end">
+              <Button
+                size="sm"
+                onClick={() => {
+                  clearWatchModeState();
+                  toast({ title: 'Watch mode data cleared' });
+                }}
+                className="neo-button bg-red-500 hover:bg-red-600"
+              >
+                <Trash2 className="w-4 h-4 mr-2" />
+                Clear Watch Mode
+              </Button>
+            </div>
           </div>
         </div>
 

--- a/src/hooks/useWatchModePersistence.ts
+++ b/src/hooks/useWatchModePersistence.ts
@@ -16,11 +16,15 @@ export const useWatchModePersistence = () => {
     if (saved) {
       try {
         const parsed = JSON.parse(saved);
+        const cap = (obj: Record<string, unknown[]>) =>
+          Object.fromEntries(
+            Object.entries(obj || {}).map(([k, v]) => [k, v.slice(0, 50)])
+          );
         return {
           lastUpdateTime: new Date(parsed.lastUpdateTime),
-          repoActivities: parsed.repoActivities || {},
-          repoPullRequests: parsed.repoPullRequests || {},
-          repoStrayBranches: parsed.repoStrayBranches || {},
+          repoActivities: cap(parsed.repoActivities),
+          repoPullRequests: cap(parsed.repoPullRequests),
+          repoStrayBranches: cap(parsed.repoStrayBranches),
           repoLastFetched: parsed.repoLastFetched || {}
         };
       } catch (error) {
@@ -43,11 +47,15 @@ export const useWatchModePersistence = () => {
       if (e.key === WATCH_MODE_STORAGE_KEY && e.newValue) {
         try {
           const parsed = JSON.parse(e.newValue);
+          const cap = (obj: Record<string, unknown[]>) =>
+            Object.fromEntries(
+              Object.entries(obj || {}).map(([k, v]) => [k, v.slice(0, 50)])
+            );
           setWatchModeState({
             lastUpdateTime: new Date(parsed.lastUpdateTime),
-            repoActivities: parsed.repoActivities || {},
-            repoPullRequests: parsed.repoPullRequests || {},
-            repoStrayBranches: parsed.repoStrayBranches || {},
+            repoActivities: cap(parsed.repoActivities),
+            repoPullRequests: cap(parsed.repoPullRequests),
+            repoStrayBranches: cap(parsed.repoStrayBranches),
             repoLastFetched: parsed.repoLastFetched || {},
           });
         } catch (error) {
@@ -67,7 +75,10 @@ export const useWatchModePersistence = () => {
   const updateRepoActivities = (repoId: string, activities: unknown[]) => {
     setWatchModeState(prev => ({
       ...prev,
-      repoActivities: { ...prev.repoActivities, [repoId]: activities }
+      repoActivities: {
+        ...prev.repoActivities,
+        [repoId]: activities.slice(0, 50)
+      }
     }));
   };
 
@@ -87,14 +98,20 @@ export const useWatchModePersistence = () => {
   const updateRepoPullRequests = (repoId: string, prs: unknown[]) => {
     setWatchModeState(prev => ({
       ...prev,
-      repoPullRequests: { ...prev.repoPullRequests, [repoId]: prs }
+      repoPullRequests: {
+        ...prev.repoPullRequests,
+        [repoId]: prs.slice(0, 50)
+      }
     }));
   };
 
   const updateRepoStrayBranches = (repoId: string, branches: string[]) => {
     setWatchModeState(prev => ({
       ...prev,
-      repoStrayBranches: { ...prev.repoStrayBranches, [repoId]: branches }
+      repoStrayBranches: {
+        ...prev.repoStrayBranches,
+        [repoId]: branches.slice(0, 50)
+      }
     }));
   };
 
@@ -109,6 +126,17 @@ export const useWatchModePersistence = () => {
     setWatchModeState(prev => ({ ...prev, lastUpdateTime }));
   };
 
+  const clearWatchModeState = () => {
+    localStorage.removeItem(WATCH_MODE_STORAGE_KEY);
+    setWatchModeState({
+      lastUpdateTime: new Date(),
+      repoActivities: {},
+      repoPullRequests: {},
+      repoStrayBranches: {},
+      repoLastFetched: {}
+    });
+  };
+
   return {
     watchModeState,
     updateRepoActivities,
@@ -116,6 +144,7 @@ export const useWatchModePersistence = () => {
     updateRepoStrayBranches,
     updateLastUpdateTime,
     updateRepoLastFetched,
-    reorderRepoActivity
+    reorderRepoActivity,
+    clearWatchModeState
   };
 };


### PR DESCRIPTION
## Summary
- keep only the last 50 items when storing watch mode arrays
- add a helper to clear watch mode state from local storage
- expose this helper via `useWatchModePersistence`
- add a button in global settings to clear watch mode data

## Testing
- `npm test`
- `npm run lint` *(fails: many lint errors)*

------
https://chatgpt.com/codex/tasks/task_e_686f333de0d48325acc4a53c316be84b