### PR TITLE
Fix duplicate function in useWatchModePersistence

### DIFF
--- a/src/hooks/useWatchModePersistence.ts
+++ b/src/hooks/useWatchModePersistence.ts
@@ -44,17 +44,7 @@ export const useWatchModePersistence = () => {
     };
   });
 
-  const clearWatchModeState = () => {
-    const initialState: WatchModeState = {
-      lastUpdateTime: new Date(),
-      repoActivities: {},
-      repoPullRequests: {},
-      repoStrayBranches: {},
-      repoLastFetched: {}
-    };
-    setWatchModeState(initialState);
-    localStorage.removeItem(WATCH_MODE_STORAGE_KEY);
-  };
+
 
   // keep state in sync across components using storage events
   useEffect(() => {


### PR DESCRIPTION
## Summary
- fix duplicate `clearWatchModeState` declaration in `useWatchModePersistence`

## Testing
- `bun x vitest run` *(fails: ReferenceError: Cannot access 'dispose' before initialization)*

------
https://chatgpt.com/codex/tasks/task_e_686f36635ffc8325a0c8f3c0b5e99ab8