### PR TITLE
Migrate app persistence to IndexedDB

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -45,6 +45,7 @@
         "crypto-js": "^4.2.0",
         "date-fns": "^3.6.0",
         "embla-carousel-react": "^8.3.0",
+        "idb-keyval": "^6.2.2",
         "input-otp": "^1.2.4",
         "lucide-react": "^0.462.0",
         "next-themes": "^0.3.0",
@@ -4874,6 +4875,12 @@
       "engines": {
         "node": ">= 0.4"
       }
+    },
+    "node_modules/idb-keyval": {
+      "version": "6.2.2",
+      "resolved": "https://registry.npmjs.org/idb-keyval/-/idb-keyval-6.2.2.tgz",
+      "integrity": "sha512-yjD9nARJ/jb1g+CvD0tlhUHOrJ9Sy0P8T9MF3YaLlHnSRpwPfpTX0XIvpmw3gAJUmEu3FiICLBDPXVwyEvrleg==",
+      "license": "Apache-2.0"
     },
     "node_modules/ignore": {
       "version": "5.3.2",

--- a/package.json
+++ b/package.json
@@ -49,6 +49,7 @@
     "crypto-js": "^4.2.0",
     "date-fns": "^3.6.0",
     "embla-carousel-react": "^8.3.0",
+    "idb-keyval": "^6.2.2",
     "input-otp": "^1.2.4",
     "lucide-react": "^0.462.0",
     "next-themes": "^0.3.0",

--- a/src/components/SecurityManagement.tsx
+++ b/src/components/SecurityManagement.tsx
@@ -46,8 +46,8 @@ export const SecurityManagement: React.FC<SecurityManagementProps> = ({ apiKeys,
 
   useEffect(() => {
     setPasskeySupported(PasskeyService.isSupported());
-    setCredentials(PasskeyService.getStoredCredentials());
-    setWebhooks(WebhookService.getWebhooks());
+    PasskeyService.getStoredCredentials().then(setCredentials);
+    WebhookService.getWebhooks().then(setWebhooks);
   }, []);
 
   const handleRegisterPasskey = async () => {
@@ -58,7 +58,7 @@ export const SecurityManagement: React.FC<SecurityManagementProps> = ({ apiKeys,
 
     const result = await PasskeyService.register(username);
     if (result.success) {
-      setCredentials(PasskeyService.getStoredCredentials());
+      PasskeyService.getStoredCredentials().then(setCredentials);
       toast({ title: "Passkey registered successfully!" });
       setShowPasskeyDialog(false);
       setUsername('');
@@ -79,8 +79,8 @@ export const SecurityManagement: React.FC<SecurityManagementProps> = ({ apiKeys,
       setCredentialToDelete(null);
       return;
     }
-    PasskeyService.removeCredential(credentialToDelete);
-    setCredentials(PasskeyService.getStoredCredentials());
+    await PasskeyService.removeCredential(credentialToDelete);
+    PasskeyService.getStoredCredentials().then(setCredentials);
     setCredentialToDelete(null);
     toast({ title: 'Passkey removed' });
   };
@@ -98,16 +98,18 @@ export const SecurityManagement: React.FC<SecurityManagementProps> = ({ apiKeys,
       created: new Date()
     };
 
-    WebhookService.saveWebhook(webhook);
-    setWebhooks(WebhookService.getWebhooks());
+    WebhookService.saveWebhook(webhook).then(() =>
+      WebhookService.getWebhooks().then(setWebhooks)
+    );
     setNewWebhook({ name: '', url: '', secret: '', events: [] });
     setShowWebhookDialog(false);
     toast({ title: "Webhook configured successfully!" });
   };
 
   const handleDeleteWebhook = (id: string) => {
-    WebhookService.deleteWebhook(id);
-    setWebhooks(WebhookService.getWebhooks());
+    WebhookService.deleteWebhook(id).then(() =>
+      WebhookService.getWebhooks().then(setWebhooks)
+    );
     toast({ title: "Webhook deleted" });
   };
 

--- a/src/components/ThemeToggle.tsx
+++ b/src/components/ThemeToggle.tsx
@@ -1,4 +1,5 @@
-import React, { useState, useEffect } from 'react';
+import React, { useEffect } from 'react';
+import { setItem } from '@/utils/storage';
 import { Sun, Moon } from 'lucide-react';
 import { Button } from '@/components/ui/button';
 
@@ -10,7 +11,7 @@ interface ThemeToggleProps {
 export const ThemeToggle = ({ theme, onThemeChange }: ThemeToggleProps) => {
   useEffect(() => {
     document.documentElement.setAttribute('data-theme', theme);
-    localStorage.setItem('theme', theme);
+    setItem('theme', theme);
   }, [theme]);
 
   const toggleTheme = () => {

--- a/src/utils/storage.ts
+++ b/src/utils/storage.ts
@@ -1,0 +1,29 @@
+import { createStore, get, set, del } from 'idb-keyval';
+
+const store = createStore('automerger-db', 'store');
+
+export async function getItem<T>(key: string): Promise<T | null> {
+  try {
+    const value = await get<T>(key, store);
+    return value ?? null;
+  } catch (err) {
+    console.error('IndexedDB getItem error', err);
+    return null;
+  }
+}
+
+export async function setItem<T>(key: string, value: T): Promise<void> {
+  try {
+    await set(key, value, store);
+  } catch (err) {
+    console.error('IndexedDB setItem error', err);
+  }
+}
+
+export async function removeItem(key: string): Promise<void> {
+  try {
+    await del(key, store);
+  } catch (err) {
+    console.error('IndexedDB removeItem error', err);
+  }
+}


### PR DESCRIPTION
## Summary
- add IndexedDB storage wrapper
- refactor hooks to use IndexedDB instead of `localStorage`
- update passkey and webhook services for async IndexedDB API
- adapt security management and theme toggle components
- install `idb-keyval` dependency

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_686f361f9c088325b9212524135df4ad