### PR TITLE
Fix duplicate clearWatchModeState declaration

### DIFF
--- a/src/hooks/useWatchModePersistence.ts
+++ b/src/hooks/useWatchModePersistence.ts
@@ -127,17 +127,6 @@ export const useWatchModePersistence = () => {
     setWatchModeState(prev => ({ ...prev, lastUpdateTime }));
   };
 
-  const clearWatchModeState = () => {
-    removeItem(WATCH_MODE_STORAGE_KEY);
-    setWatchModeState({
-      lastUpdateTime: new Date(),
-      repoActivities: {},
-      repoPullRequests: {},
-      repoStrayBranches: {},
-      repoLastFetched: {}
-    });
-  };
-
   return {
     watchModeState,
     updateRepoActivities,


### PR DESCRIPTION
## Summary
- remove the second `clearWatchModeState` declaration in `useWatchModePersistence`

## Testing
- `npm test`
- `npm run build`
- `npm run lint` *(fails: 53 errors, 18 warnings)*

------
https://chatgpt.com/codex/tasks/task_e_686f395814e88325911929faaa5c0d29