### PR TITLE
Remove wrapper div around ConnectionManager

### DIFF
--- a/src/components/DashboardHeader.tsx
+++ b/src/components/DashboardHeader.tsx
@@ -21,9 +21,7 @@ export const DashboardHeader: React.FC<DashboardHeaderProps> = ({ apiKeys = [] }
               <p className="text-muted-foreground font-bold">Automated pull request management system</p>
             </div>
           </div>
-          <div className="flex items-center gap-4">
-            <ConnectionManager apiKeys={apiKeys} compact={true} />
-          </div>
+          <ConnectionManager apiKeys={apiKeys} compact={true} />
         </div>
       </CardHeader>
     </Card>


### PR DESCRIPTION
## Summary
- clean up DashboardHeader by removing unnecessary wrapper div around `ConnectionManager`

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_686fa33bf94c83258f15167696b964ef