### PR TITLE
Add repo toggle activities

### DIFF
--- a/src/components/GlobalConfiguration.tsx
+++ b/src/components/GlobalConfiguration.tsx
@@ -441,7 +441,7 @@ export const GlobalConfiguration: React.FC<GlobalConfigurationProps> = ({
              />
             <ConfigToggle
                id="autoDeleteOnDirty"
-               label="Auto Delete Dirty Branches"
+               label="Auto Delete on Dirty Branches"
                checked={config.autoDeleteOnDirty}
                onCheckedChange={(checked) => onConfigChange({ ...config, autoDeleteOnDirty: checked })}
              />

--- a/src/components/RepositoryCard.tsx
+++ b/src/components/RepositoryCard.tsx
@@ -107,7 +107,7 @@ export const RepositoryCard: React.FC<RepositoryCardProps> = ({
                   {repo.enabled ? 'Active' : 'Inactive'}
                 </Badge>
                 <Badge variant="secondary" className={`neo-card ${repo.autoMergeOnClean ? 'neo-green' : 'neo-red'} text-black font-bold text-xs`}>
-                  {repo.autoMergeOnClean ? 'Automerge Clean' : 'Automerge Clean Off'}
+                  {repo.autoMergeOnClean ? 'Automerge on Clean' : 'Automerge on Clean Off'}
                 </Badge>
                 <Badge variant="secondary" className="neo-card neo-blue text-black font-bold text-xs">
                   {successRate}% Success
@@ -185,8 +185,8 @@ export const RepositoryCard: React.FC<RepositoryCardProps> = ({
             {/* Auto-merge Toggle */}
             <div className="flex items-center justify-between">
               <div>
-                <h4 className="font-black text-sm">Auto-merge</h4>
-                <p className="text-xs text-muted-foreground">Automatically merge PRs when checks pass</p>
+                <h4 className="font-black text-sm">Auto-merge on Clean</h4>
+                <p className="text-xs text-muted-foreground">Automatically merge PRs when the merge state is clean</p>
               </div>
               <Switch
                 checked={repo.autoMergeOnClean}

--- a/src/components/RepositoryManagement.tsx
+++ b/src/components/RepositoryManagement.tsx
@@ -152,7 +152,7 @@ export const RepositoryManagement: React.FC<RepositoryManagementProps> = ({
                       </CardTitle>
                       <CardDescription className="font-bold">
                         {repo.enabled ? 'Active' : 'Inactive'} |
-                        {repo.autoMergeOnClean ? ' Automerge Clean' : ' Automerge Clean Off'}
+                        {repo.autoMergeOnClean ? ' Automerge on Clean' : ' Automerge on Clean Off'}
                       </CardDescription>
                     </div>
                   </div>
@@ -314,7 +314,7 @@ export const RepositoryManagement: React.FC<RepositoryManagementProps> = ({
                       />
                     </div>
                     <div className="flex items-center justify-between">
-                      <span className="font-bold">Auto Merge Clean</span>
+                      <span className="font-bold">Auto Merge on Clean</span>
                       <Switch
                         checked={repo.autoMergeOnClean}
                         onCheckedChange={() => onToggleAutoMergeOnClean(repo.id)}
@@ -328,7 +328,7 @@ export const RepositoryManagement: React.FC<RepositoryManagementProps> = ({
                       />
                     </div>
                     <div className="flex items-center justify-between">
-                      <span className="font-bold">Auto Delete Dirty</span>
+                      <span className="font-bold">Auto Delete on Dirty</span>
                       <Switch
                         checked={repo.autoDeleteOnDirty ?? false}
                         onCheckedChange={() => onToggleDeleteOnDirty(repo.id)}

--- a/src/hooks/useRepositories.ts
+++ b/src/hooks/useRepositories.ts
@@ -77,10 +77,12 @@ export const useRepositories = () => {
   };
 
   const toggleAutoMergeOnClean = (id: string) => {
+    let updatedRepo: { owner: string; name: string; status: boolean } | null = null;
     setRepositories(repos =>
       repos.map(repo => {
         if (repo.id === id) {
           const newStatus = !repo.autoMergeOnClean;
+          updatedRepo = { owner: repo.owner, name: repo.name, status: newStatus };
           logInfo('repository', `Auto-merge on clean for ${repo.name} ${newStatus ? 'enabled' : 'disabled'}`, { repo: repo.name, autoMergeOnClean: newStatus });
           toast({
             title: `Auto-merge on clean ${newStatus ? 'enabled' : 'disabled'} for ${repo.name}`,
@@ -91,16 +93,36 @@ export const useRepositories = () => {
         return repo;
       })
     );
+    if (updatedRepo) {
+      addRepositoryActivity(id, {
+        type: 'alert',
+        message: `merge clean ${updatedRepo.status ? 'on' : 'off'}`,
+        repo: `${updatedRepo.owner}/${updatedRepo.name}`,
+        timestamp: new Date()
+      });
+    }
   };
 
   const toggleAutoMergeOnUnstable = (id: string) => {
+    let updatedRepo: { owner: string; name: string; status: boolean } | null = null;
     setRepositories(repos =>
-      repos.map(repo =>
-        repo.id === id
-          ? { ...repo, autoMergeOnUnstable: !repo.autoMergeOnUnstable }
-          : repo
-      )
+      repos.map(repo => {
+        if (repo.id === id) {
+          const newStatus = !repo.autoMergeOnUnstable;
+          updatedRepo = { owner: repo.owner, name: repo.name, status: newStatus };
+          return { ...repo, autoMergeOnUnstable: newStatus };
+        }
+        return repo;
+      })
     );
+    if (updatedRepo) {
+      addRepositoryActivity(id, {
+        type: 'alert',
+        message: `merge unstable ${updatedRepo.status ? 'on' : 'off'}`,
+        repo: `${updatedRepo.owner}/${updatedRepo.name}`,
+        timestamp: new Date()
+      });
+    }
   };
 
   const toggleWatch = (id: string) => {
@@ -112,11 +134,25 @@ export const useRepositories = () => {
   };
 
   const toggleDeleteOnDirty = (id: string) => {
+    let updatedRepo: { owner: string; name: string; status: boolean } | null = null;
     setRepositories(repos =>
-      repos.map(repo =>
-        repo.id === id ? { ...repo, autoDeleteOnDirty: !repo.autoDeleteOnDirty } : repo
-      )
+      repos.map(repo => {
+        if (repo.id === id) {
+          const newStatus = !repo.autoDeleteOnDirty;
+          updatedRepo = { owner: repo.owner, name: repo.name, status: newStatus };
+          return { ...repo, autoDeleteOnDirty: newStatus };
+        }
+        return repo;
+      })
     );
+    if (updatedRepo) {
+      addRepositoryActivity(id, {
+        type: 'alert',
+        message: `del dirty ${updatedRepo.status ? 'on' : 'off'}`,
+        repo: `${updatedRepo.owner}/${updatedRepo.name}`,
+        timestamp: new Date()
+      });
+    }
   };
 
   const toggleCloseBranch = (id: string) => {


### PR DESCRIPTION
## Summary
- log activity when toggling repository auto merge and delete settings
- update UI labels for those toggles

## Testing
- `npm run lint` *(fails: unexpected any and require import issues)*
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_686fa7bf4b9883259e98f951ac9ea455