### PR TITLE
Add update check and auto-archive options

### DIFF
--- a/src/components/GlobalConfiguration.tsx
+++ b/src/components/GlobalConfiguration.tsx
@@ -8,7 +8,7 @@ import { Badge } from '@/components/ui/badge';
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@/components/ui/select';
 import { Dialog, DialogContent, DialogHeader, DialogTitle, DialogTrigger } from '@/components/ui/dialog';
 import { Checkbox } from '@/components/ui/checkbox';
-import { Settings, Plus, Trash2, Download, Upload, Shield, Lock, Webhook } from 'lucide-react';
+import { Settings, Plus, Trash2, Download, Upload, Shield, Lock, Webhook, RefreshCw } from 'lucide-react';
 import { useToast } from '@/hooks/use-toast';
 import { GlobalConfig, Repository, ApiKey } from '@/types/dashboard';
 import { ExportImportService, ExportOptions, SecurityConfig } from '@/utils/exportImport';
@@ -19,6 +19,7 @@ import { ConfigSelector } from '@/components/ConfigSelector';
 import { EditableList } from '@/components/EditableList';
 import { useLogger } from '@/hooks/useLogger';
 import { useWatchModePersistence } from '@/hooks/useWatchModePersistence';
+import { checkUserscriptUpdates } from '@/utils/updateChecker';
 
 interface GlobalConfigurationProps {
   config: GlobalConfig;
@@ -199,6 +200,18 @@ export const GlobalConfiguration: React.FC<GlobalConfigurationProps> = ({
     }
   };
 
+  const handleCheckUpdates = async () => {
+    const result = await checkUserscriptUpdates();
+    if (result.hasUpdate) {
+      toast({
+        title: 'Update available',
+        description: `Latest version ${result.latestVersion}`
+      });
+    } else {
+      toast({ title: 'No updates found' });
+    }
+  };
+
   return (
     <Card className="neo-card">
       <CardHeader>
@@ -357,6 +370,10 @@ export const GlobalConfiguration: React.FC<GlobalConfigurationProps> = ({
                 </div>
               </DialogContent>
               </Dialog>
+              <Button onClick={handleCheckUpdates} className="neo-button-secondary" size="sm">
+                <RefreshCw className="w-4 h-4 mr-2" />
+                Check Updates
+              </Button>
             </div>
           </div>
         </div>
@@ -445,12 +462,24 @@ export const GlobalConfiguration: React.FC<GlobalConfigurationProps> = ({
                checked={config.autoDeleteOnDirty}
                onCheckedChange={(checked) => onConfigChange({ ...config, autoDeleteOnDirty: checked })}
              />
-            <ConfigToggle
-               id="confirmBranchDeletion"
-               label="Confirm Branch Deletion"
-               checked={config.confirmBranchDeletion}
-               onCheckedChange={(checked) => onConfigChange({ ...config, confirmBranchDeletion: checked })}
-             />
+              <ConfigToggle
+                id="confirmBranchDeletion"
+                label="Confirm Branch Deletion"
+                checked={config.confirmBranchDeletion}
+                onCheckedChange={(checked) => onConfigChange({ ...config, confirmBranchDeletion: checked })}
+              />
+              <ConfigToggle
+                id="autoArchiveClose"
+                label="Auto-Archive on Close"
+                checked={config.autoArchiveClose}
+                onCheckedChange={(checked) => onConfigChange({ ...config, autoArchiveClose: checked })}
+              />
+              <ConfigToggle
+                id="autoArchiveClosed"
+                label="Auto-Archive Closed PRs"
+                checked={config.autoArchiveClosed}
+                onCheckedChange={(checked) => onConfigChange({ ...config, autoArchiveClosed: checked })}
+              />
             <div className="grid grid-cols-2 items-center gap-4">
                 <div className="flex items-center gap-2">
                   <Label htmlFor="allowAllBranches" className="font-bold">Allow All Branches</Label>
@@ -589,13 +618,19 @@ export const GlobalConfiguration: React.FC<GlobalConfigurationProps> = ({
               checked={config.hideHeader}
               onCheckedChange={(checked) => onConfigChange({ ...config, hideHeader: checked })}
             />
-            <ConfigToggle
-              id="logsDisabled"
-              label="Disable Logs"
-              checked={config.logsDisabled}
-              onCheckedChange={(checked) => onConfigChange({ ...config, logsDisabled: checked })}
-            />
-            <div className="flex justify-end">
+              <ConfigToggle
+                id="logsDisabled"
+                label="Disable Logs"
+                checked={config.logsDisabled}
+                onCheckedChange={(checked) => onConfigChange({ ...config, logsDisabled: checked })}
+              />
+              <ConfigToggle
+                id="checkUserscriptUpdates"
+                label="Check Userscript Updates"
+                checked={config.checkUserscriptUpdates}
+                onCheckedChange={(checked) => onConfigChange({ ...config, checkUserscriptUpdates: checked })}
+              />
+              <div className="flex justify-end">
               <Button
                 size="sm"
                 onClick={() => {

--- a/src/components/WatchMode.tsx
+++ b/src/components/WatchMode.tsx
@@ -232,7 +232,9 @@ export const WatchMode: React.FC<WatchModeProps> = ({ repositories, apiKeys, get
     const success = await service.mergePullRequest(repo.owner, repo.name, prNumber);
     if (success) {
       toast({ title: `Merged PR #${prNumber} successfully` });
-      updateRepoPullRequests(repo.id, (repoPullRequests[repo.id] || []).filter(pr => pr.number !== prNumber));
+      if (globalConfig.autoArchiveClosed) {
+        updateRepoPullRequests(repo.id, (repoPullRequests[repo.id] || []).filter(pr => pr.number !== prNumber));
+      }
       const branches = await service.fetchStrayBranches(repo.owner, repo.name);
       updateRepoStrayBranches(repo.id, branches);
       fetchRepoData(repo);
@@ -257,7 +259,9 @@ export const WatchMode: React.FC<WatchModeProps> = ({ repositories, apiKeys, get
     const success = await service.closePullRequest(repo.owner, repo.name, prNumber);
     if (success) {
       toast({ title: `Closed PR #${prNumber}` });
-      updateRepoPullRequests(repo.id, (repoPullRequests[repo.id] || []).filter(pr => pr.number !== prNumber));
+      if (globalConfig.autoArchiveClose) {
+        updateRepoPullRequests(repo.id, (repoPullRequests[repo.id] || []).filter(pr => pr.number !== prNumber));
+      }
       const branches = await service.fetchStrayBranches(repo.owner, repo.name);
       updateRepoStrayBranches(repo.id, branches);
       fetchRepoData(repo);

--- a/src/hooks/useGlobalConfig.ts
+++ b/src/hooks/useGlobalConfig.ts
@@ -32,7 +32,10 @@ const getDefaultConfig = (): GlobalConfig => ({
   hideHeader: false,
   logsDisabled: false,
   protectedBranches: ['main'],
-  confirmBranchDeletion: true
+  confirmBranchDeletion: true,
+  checkUserscriptUpdates: true,
+  autoArchiveClose: false,
+  autoArchiveClosed: false
 });
 
 export const useGlobalConfig = () => {

--- a/src/types/dashboard.ts
+++ b/src/types/dashboard.ts
@@ -167,5 +167,11 @@ export interface GlobalConfig {
   logsDisabled: boolean;
   protectedBranches: string[];
   confirmBranchDeletion: boolean;
+  /** Check for userscript updates automatically */
+  checkUserscriptUpdates: boolean;
+  /** Archive PRs automatically when closing */
+  autoArchiveClose: boolean;
+  /** Archive already closed PRs when fetching */
+  autoArchiveClosed: boolean;
   refreshInterval: number;
 }

--- a/src/utils/updateChecker.ts
+++ b/src/utils/updateChecker.ts
@@ -1,0 +1,22 @@
+export interface UpdateResult {
+  hasUpdate: boolean;
+  latestVersion?: string;
+}
+
+const UPDATE_API = 'https://api.github.com/repos/openai/codex-automerger-userscript/releases/latest';
+
+export async function checkUserscriptUpdates(): Promise<UpdateResult> {
+  try {
+    const res = await fetch(UPDATE_API, { headers: { 'Accept': 'application/json' } });
+    if (!res.ok) {
+      throw new Error('Network error');
+    }
+    const data = await res.json();
+    const latest = data.tag_name || data.name;
+    const current = (window as any).__USERSCRIPT_VERSION__;
+    return { hasUpdate: current ? latest !== current : false, latestVersion: latest };
+  } catch (err) {
+    console.error('Failed to check userscript updates', err);
+    return { hasUpdate: false };
+  }
+}


### PR DESCRIPTION
## Summary
- extend `GlobalConfig` with update and archive options
- provide defaults for the new settings
- add update check button and toggles in the configuration UI
- add `updateChecker` utility for checking latest userscript version
- respect auto-archive flags when closing or merging PRs

## Testing
- `npm run lint` *(fails: Unexpected any, missing deps, etc.)*
- `npm run test` *(fails: Cannot find package 'lovable-tagger')*

------
https://chatgpt.com/codex/tasks/task_e_686feed3713c832596384b2251af4d5c