### PR TITLE
Implement socket pairing handshake

### DIFF
--- a/server/index.js
+++ b/server/index.js
@@ -1,6 +1,7 @@
 import express from 'express';
 import http from 'http';
 import { Server } from 'socket.io';
+import crypto from 'crypto';
 import { createGitHubService } from './github.js';
 import { subscribeRepo, unsubscribeRepo } from './watchers.js';
 
@@ -12,9 +13,38 @@ const io = new Server(httpServer, {
   }
 });
 
+const pairedClients = new Set();
+
+function requirePaired(socket, cb) {
+  if (!socket.isPaired) {
+    if (typeof cb === 'function') {
+      cb({ ok: false, error: 'client not paired' });
+    }
+    return false;
+  }
+  return true;
+}
+
 io.on('connection', socket => {
   socket.subscriptions = new Set();
+  socket.isPaired = false;
+  socket.pairToken = crypto.randomBytes(8).toString('hex');
+  socket.clientId = null;
+
+  socket.emit('pair_request', { token: socket.pairToken });
+
+  socket.on('pair_approved', ({ token, clientId }) => {
+    if (token === socket.pairToken) {
+      socket.isPaired = true;
+      socket.clientId = clientId;
+      pairedClients.add(clientId);
+      socket.emit('pair_approved', { success: true });
+    } else {
+      socket.emit('pair_approved', { success: false, error: 'invalid token' });
+    }
+  });
   socket.on('fetchRepos', async (params, cb = () => {}) => {
+    if (!requirePaired(socket, cb)) return;
     try {
       const svc = createGitHubService(params.token);
       const repos = await svc.fetchRepositories(params.owner || '');
@@ -25,6 +55,7 @@ io.on('connection', socket => {
   });
 
   socket.on('fetchPullRequests', async (params, cb = () => {}) => {
+    if (!requirePaired(socket, cb)) return;
     try {
       const svc = createGitHubService(params.token);
       const pulls = await svc.fetchPullRequests(params.owner, params.repo);
@@ -35,6 +66,7 @@ io.on('connection', socket => {
   });
 
   socket.on('mergePR', async (params, cb = () => {}) => {
+    if (!requirePaired(socket, cb)) return;
     try {
       const svc = createGitHubService(params.token);
       await svc.mergePullRequest(params.owner, params.repo, params.pullNumber);
@@ -45,6 +77,7 @@ io.on('connection', socket => {
   });
 
   socket.on('closePR', async (params, cb = () => {}) => {
+    if (!requirePaired(socket, cb)) return;
     try {
       const svc = createGitHubService(params.token);
       await svc.closePullRequest(params.owner, params.repo, params.pullNumber);
@@ -55,6 +88,7 @@ io.on('connection', socket => {
   });
 
   socket.on('deleteBranch', async (params, cb = () => {}) => {
+    if (!requirePaired(socket, cb)) return;
     try {
       const svc = createGitHubService(params.token);
       await svc.deleteBranch(params.owner, params.repo, params.branch);
@@ -65,6 +99,7 @@ io.on('connection', socket => {
   });
 
   socket.on('fetchStrayBranches', async (params, cb = () => {}) => {
+    if (!requirePaired(socket, cb)) return;
     try {
       const svc = createGitHubService(params.token);
       const branches = await svc.fetchStrayBranches(params.owner, params.repo);
@@ -75,6 +110,7 @@ io.on('connection', socket => {
   });
 
   socket.on('fetchRecentActivity', async (params, cb = () => {}) => {
+    if (!requirePaired(socket, cb)) return;
     try {
       const svc = createGitHubService(params.token);
       const data = await svc.fetchRecentActivity(params.repositories);
@@ -85,16 +121,19 @@ io.on('connection', socket => {
   });
 
   socket.on('subscribeRepo', params => {
+    if (!requirePaired(socket)) return;
     subscribeRepo(socket, params);
     socket.subscriptions.add(`${params.owner}/${params.repo}`);
   });
 
   socket.on('unsubscribeRepo', params => {
+    if (!requirePaired(socket)) return;
     unsubscribeRepo(socket, params);
     socket.subscriptions.delete(`${params.owner}/${params.repo}`);
   });
 
   socket.on('checkPRMergeable', async (params, cb = () => {}) => {
+    if (!requirePaired(socket, cb)) return;
     try {
       const svc = createGitHubService(params.token);
       const ok = await svc.checkPullRequestMergeable(params.owner, params.repo, params.pullNumber);
@@ -108,6 +147,9 @@ io.on('connection', socket => {
     for (const key of socket.subscriptions) {
       const [owner, repo] = key.split('/');
       unsubscribeRepo(socket, { owner, repo });
+    }
+    if (socket.clientId) {
+      pairedClients.delete(socket.clientId);
     }
   });
 });


### PR DESCRIPTION
## Summary
- add pairing token generation on new socket connections
- store paired client IDs and validate commands
- emit `pair_request` and `pair_approved` events
- reject all command events from unpaired clients

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68717d17020c8325a208070511a15ded