### PR TITLE
Fix theme color references

### DIFF
--- a/src/components/StatsCards.tsx
+++ b/src/components/StatsCards.tsx
@@ -64,7 +64,7 @@ export const StatsCards: React.FC<StatsCardsProps> = ({ repositories, apiKeys, m
       {stats.map((stat, index) => (
         <Card
           key={index}
-          className={`neo-card ${stat.color} p-2 shadow-[4px_4px_0_theme('colors.foreground')]`}
+          className={`neo-card ${stat.color} p-2 shadow-[4px_4px_0_hsl(var(--foreground))]`}
         >
           <CardHeader className="pb-1">
             <CardTitle className="text-black dark:text-white font-black text-lg text-center">

--- a/src/index.css
+++ b/src/index.css
@@ -101,7 +101,7 @@
 
 @layer components {
   .neo-card {
-    @apply bg-card border-4 border-foreground shadow-[8px_8px_0px_0px_theme('colors.foreground')];
+    @apply bg-card border-4 border-foreground shadow-[8px_8px_0px_0px_hsl(var(--foreground))];
   }
   
   .neo-card.neo-yellow { @apply bg-[hsl(var(--neo-yellow))] text-black border-foreground; }
@@ -121,15 +121,15 @@
   .dark .neo-card.neo-red { @apply text-white border-2 border-gray-600; }
   
   .neo-button {
-    @apply bg-primary border-4 border-foreground shadow-[4px_4px_0px_0px_theme('colors.foreground')]
-           hover:shadow-[2px_2px_0px_0px_theme('colors.foreground')]
+    @apply bg-primary border-4 border-foreground shadow-[4px_4px_0px_0px_hsl(var(--foreground))]
+           hover:shadow-[2px_2px_0px_0px_hsl(var(--foreground))]
            hover:translate-x-[2px] hover:translate-y-[2px] 
            transition-all duration-150 font-black uppercase tracking-wider;
   }
   
   .neo-button-secondary {
-    @apply bg-secondary border-4 border-foreground shadow-[4px_4px_0px_0px_theme('colors.foreground')]
-           hover:shadow-[2px_2px_0px_0px_theme('colors.foreground')]
+    @apply bg-secondary border-4 border-foreground shadow-[4px_4px_0px_0px_hsl(var(--foreground))]
+           hover:shadow-[2px_2px_0px_0px_hsl(var(--foreground))]
            hover:translate-x-[2px] hover:translate-y-[2px]
            transition-all duration-150 font-black uppercase tracking-wider;
   }
@@ -139,14 +139,14 @@
   }
   
   .neo-input {
-    @apply bg-background border-4 border-foreground shadow-[4px_4px_0px_0px_theme('colors.foreground')]
-           focus:shadow-[2px_2px_0px_0px_theme('colors.foreground')]
+    @apply bg-background border-4 border-foreground shadow-[4px_4px_0px_0px_hsl(var(--foreground))]
+           focus:shadow-[2px_2px_0px_0px_hsl(var(--foreground))]
            focus:translate-x-[2px] focus:translate-y-[2px] 
            transition-all duration-150 font-bold;
   }
 
   .neo-switch {
-    @apply bg-background border-4 border-foreground shadow-[4px_4px_0px_0px_theme('colors.foreground')] rounded-full;
+    @apply bg-background border-4 border-foreground shadow-[4px_4px_0px_0px_hsl(var(--foreground))] rounded-full;
   }
 
   .neo-switch-thumb {
@@ -157,11 +157,11 @@
 
 @layer utilities {
   .text-shadow {
-    text-shadow: 2px 2px 0px theme('colors.foreground');
+    text-shadow: 2px 2px 0px hsl(var(--foreground));
   }
   
   .neo-hover:hover {
     transform: translateX(2px) translateY(2px);
-    box-shadow: 2px 2px 0px 0px theme('colors.foreground');
+    box-shadow: 2px 2px 0px 0px hsl(var(--foreground));
   }
 }


### PR DESCRIPTION
## Summary
- remove `theme('colors.foreground')` usage
- reference CSS variable directly for theme foreground color

## Testing
- `npm run build`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_687187c5024c8325be3fb5476ef4979f