### PR TITLE
Add caching for repo events

### DIFF
--- a/server/__tests__/watchers.test.ts
+++ b/server/__tests__/watchers.test.ts
@@ -1,0 +1,84 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { __test } from '../watchers.js';
+
+let eventsMock: any;
+let alertsMock: any;
+
+vi.mock('../github.js', () => ({
+  createGitHubService: () => ({
+    octokit: {
+      rest: {
+        activity: { listRepoEvents: (...args: any[]) => eventsMock(...args) },
+        dependabot: { listAlertsForRepo: (...args: any[]) => alertsMock(...args) }
+      }
+    }
+  })
+}));
+
+describe('watchers cache', () => {
+  let watcher: any;
+  let emit: any;
+
+  beforeEach(() => {
+    eventsMock = vi.fn();
+    alertsMock = vi.fn();
+    emit = vi.fn();
+    watcher = {
+      token: 't',
+      owner: 'o',
+      repo: 'r',
+      sockets: new Set([{ emit }]),
+      lastEvent: null,
+      alerts: new Set()
+    };
+    __test.repoCache.clear();
+  });
+
+  it('stores successful events in cache', async () => {
+    const event = { id: '1', type: 'PullRequestEvent', payload: { action: 'opened', pull_request: { number: 1 } } };
+    eventsMock.mockResolvedValue({ data: [event] });
+    alertsMock.mockResolvedValue({ data: [] });
+
+    await __test.pollRepo(watcher);
+
+    expect(__test.repoCache.get('o/r').events.length).toBe(1);
+    expect(emit).toHaveBeenCalledWith('repoUpdate', { event: 'pull_request.opened', repo: 'o/r', data: event.payload.pull_request });
+  });
+
+  it('uses cached events on fetch failure', async () => {
+    const event = { id: '1', type: 'PullRequestEvent', payload: { action: 'opened', pull_request: { number: 1 } } };
+    eventsMock.mockResolvedValue({ data: [event] });
+    alertsMock.mockResolvedValue({ data: [] });
+
+    await __test.pollRepo(watcher);
+    expect(emit).toHaveBeenCalledTimes(1);
+    emit.mockClear();
+
+    eventsMock.mockRejectedValue(new Error('fail'));
+    alertsMock.mockRejectedValue(new Error('fail'));
+
+    await __test.pollRepo(watcher);
+
+    expect(emit).toHaveBeenCalledTimes(1);
+    expect(emit).toHaveBeenCalledWith('repoUpdate', { event: 'pull_request.opened', repo: 'o/r', data: event.payload.pull_request });
+  });
+
+  it('expires cache after TTL', async () => {
+    const event = { id: '1', type: 'PullRequestEvent', payload: { action: 'opened', pull_request: { number: 1 } } };
+    eventsMock.mockResolvedValue({ data: [event] });
+    alertsMock.mockResolvedValue({ data: [] });
+
+    await __test.pollRepo(watcher);
+
+    const entry = __test.repoCache.get('o/r');
+    entry.timestamp = Date.now() - 301000;
+
+    emit.mockClear();
+    eventsMock.mockRejectedValue(new Error('fail'));
+    alertsMock.mockRejectedValue(new Error('fail'));
+
+    await __test.pollRepo(watcher);
+
+    expect(emit).toHaveBeenCalledTimes(0);
+  });
+});

--- a/server/watchers.js
+++ b/server/watchers.js
@@ -2,8 +2,17 @@ import { createGitHubService } from './github.js';
 import { WebhookService } from './webhooks.js';
 
 const DEFAULT_INTERVAL = parseInt(process.env.POLL_INTERVAL_MS || '60000', 10);
+const CACHE_TTL = parseInt(process.env.CACHE_TTL_MS || '300000', 10);
 
 const watchers = new Map();
+const repoCache = new Map();
+
+function cleanCache() {
+  const now = Date.now();
+  for (const [key, entry] of repoCache) {
+    if (now - entry.timestamp > CACHE_TTL) repoCache.delete(key);
+  }
+}
 
 export function subscribeRepo(socket, { token, owner, repo, interval }) {
   const key = `${owner}/${repo}`;
@@ -38,8 +47,14 @@ export function unsubscribeRepo(socket, { owner, repo }) {
 
 async function pollRepo(watcher) {
   const { token, owner, repo } = watcher;
+  cleanCache();
   const svc = createGitHubService(token);
   const repoKey = `${owner}/${repo}`;
+  let cacheEntry = repoCache.get(repoKey);
+  if (!cacheEntry) {
+    cacheEntry = { events: [], alerts: [], timestamp: 0 };
+    repoCache.set(repoKey, cacheEntry);
+  }
   try {
     const { data: events } = await svc.octokit.rest.activity.listRepoEvents({ owner, repo, per_page: 10 });
     for (const event of events.reverse()) {
@@ -54,8 +69,10 @@ async function pollRepo(watcher) {
         broadcast(watcher, 'security.alert', alert);
       }
     }
+    cacheEntry.timestamp = Date.now();
   } catch (err) {
     console.error('Polling error for', repoKey, err.message);
+    serveCache(watcher, cacheEntry);
   }
 }
 
@@ -74,4 +91,28 @@ function broadcast(watcher, event, data) {
   const repo = `${watcher.owner}/${watcher.repo}`;
   watcher.sockets.forEach(s => s.emit('repoUpdate', { event, repo, data }));
   WebhookService.triggerWebhooks(event, repo, data);
+
+  const cache = repoCache.get(repo) || { events: [], alerts: [], timestamp: Date.now() };
+  if (event === 'security.alert') {
+    cache.alerts.push(data);
+    if (cache.alerts.length > 10) cache.alerts.shift();
+  } else {
+    cache.events.push({ event, data });
+    if (cache.events.length > 10) cache.events.shift();
+  }
+  cache.timestamp = Date.now();
+  repoCache.set(repo, cache);
 }
+
+function serveCache(watcher, entry) {
+  if (!entry || Date.now() - entry.timestamp > CACHE_TTL) return;
+  const repo = `${watcher.owner}/${watcher.repo}`;
+  for (const e of entry.events) {
+    watcher.sockets.forEach(s => s.emit('repoUpdate', { event: e.event, repo, data: e.data }));
+  }
+  for (const alert of entry.alerts) {
+    watcher.sockets.forEach(s => s.emit('repoUpdate', { event: 'security.alert', repo, data: alert }));
+  }
+}
+
+export const __test = { repoCache, pollRepo };


### PR DESCRIPTION
## Summary
- cache last successful events and alerts in `server/watchers.js`
- serve cached data to clients when polling fails
- expire cache entries after 5 minutes
- test the new caching logic

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68718988c6b48325a5a2d1c8f477fe94