### PR TITLE
Improve theme persistence

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,3 +88,17 @@ socket clients subscribed via the `subscribeRepo` message receive a `repoUpdate`
 payload and any active webhooks are triggered. The subscribe call may include
 configuration such as protected branch patterns, allowed users or minimum alert
 severity. These settings influence polling and security filtering on the server.
+
+## Theme customization
+
+The dashboard supports a light and dark theme controlled by the **Dark Mode** toggle
+in the Global Configuration panel. The current preference is stored in local
+storage so the correct theme loads instantly on subsequent visits. To customize
+the theme:
+
+1. Open the **Global Configuration** page from the sidebar.
+2. Enable or disable **Dark Mode** to switch themes.
+3. Adjust the **Accent Color** to change primary UI highlights.
+
+Changes are persisted automatically and are applied as soon as you toggle the
+options.

--- a/index.html
+++ b/index.html
@@ -16,6 +16,23 @@
     <meta name="twitter:card" content="summary_large_image" />
     <meta name="twitter:site" content="@lovable_dev" />
     <meta name="twitter:image" content="https://lovable.dev/opengraph-image-p98pqg.png" />
+    <script>
+      (function () {
+        try {
+          const stored = localStorage.getItem('theme');
+          const theme = stored === 'light' || stored === 'dark' ? stored : 'dark';
+          document.documentElement.setAttribute('data-theme', theme);
+          if (theme === 'dark') {
+            document.documentElement.classList.add('dark');
+          } else {
+            document.documentElement.classList.remove('dark');
+          }
+        } catch (e) {
+          document.documentElement.setAttribute('data-theme', 'dark');
+          document.documentElement.classList.add('dark');
+        }
+      })();
+    </script>
   </head>
 
   <body>

--- a/src/hooks/useGlobalConfig.ts
+++ b/src/hooks/useGlobalConfig.ts
@@ -62,10 +62,15 @@ export const useGlobalConfig = () => {
     });
   }, [globalConfig]);
 
-  // Update theme in IndexedDB when darkMode changes
+  // Update theme preference whenever darkMode changes
   useEffect(() => {
     const theme = globalConfig.darkMode ? 'dark' : 'light';
     setItem('theme', theme);
+    try {
+      localStorage.setItem('theme', theme);
+    } catch (err) {
+      console.error('Error saving theme to localStorage:', err);
+    }
     document.documentElement.setAttribute('data-theme', theme);
     // Apply theme to document
     if (globalConfig.darkMode) {


### PR DESCRIPTION
## Summary
- load the saved theme from localStorage before React mounts
- persist theme preference in localStorage when toggled
- document how to customise theme in the README

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68723f326de08325a934fb865c0fdc51