### PR TITLE
Implement next-themes integration

### DIFF
--- a/src/components/Dashboard.tsx
+++ b/src/components/Dashboard.tsx
@@ -124,7 +124,13 @@ export const Dashboard = () => {
       </Dialog>
       <div className="max-w-7xl mx-auto space-y-8">
         {/* Header */}
-        {!globalConfig.hideHeader && <DashboardHeader apiKeys={apiKeys} />}
+        {!globalConfig.hideHeader && (
+          <DashboardHeader
+            apiKeys={apiKeys}
+            darkMode={globalConfig.darkMode}
+            onThemeChange={(dark) => setGlobalConfig({ darkMode: dark })}
+          />
+        )}
 
         {/* Stats Cards */}
         <StatsCards repositories={repositories} apiKeys={apiKeys} mergeStats={mergeStats} statsPeriod={globalConfig.statsPeriod} />

--- a/src/components/DashboardHeader.tsx
+++ b/src/components/DashboardHeader.tsx
@@ -1,13 +1,17 @@
 import React from 'react';
-import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
+import { Card, CardHeader, CardTitle } from '@/components/ui/card';
 import { ConnectionManager } from '@/components/ConnectionManager';
-import { Activity, GitMerge } from 'lucide-react';
+import { GitMerge } from 'lucide-react';
+import { ThemeToggle } from '@/components/ThemeToggle';
+import { ApiKey } from '@/types/dashboard';
 
 interface DashboardHeaderProps {
-  apiKeys?: any[];
+  apiKeys?: ApiKey[];
+  darkMode: boolean;
+  onThemeChange: (dark: boolean) => void;
 }
 
-export const DashboardHeader: React.FC<DashboardHeaderProps> = ({ apiKeys = [] }) => {
+export const DashboardHeader: React.FC<DashboardHeaderProps> = ({ apiKeys = [], darkMode, onThemeChange }) => {
   return (
     <Card className="neo-card">
       <CardHeader>
@@ -21,7 +25,10 @@ export const DashboardHeader: React.FC<DashboardHeaderProps> = ({ apiKeys = [] }
               <p className="text-muted-foreground font-bold">Automated pull request management system</p>
             </div>
           </div>
-          <ConnectionManager apiKeys={apiKeys} compact={true} />
+          <div className="flex items-center gap-2">
+            <ThemeToggle darkMode={darkMode} onThemeChange={onThemeChange} />
+            <ConnectionManager apiKeys={apiKeys} compact={true} />
+          </div>
         </div>
       </CardHeader>
     </Card>

--- a/src/components/ThemeToggle.tsx
+++ b/src/components/ThemeToggle.tsx
@@ -1,21 +1,20 @@
-import React, { useEffect } from 'react';
-import { setItem } from '@/utils/storage';
+import React from 'react';
+import { useTheme } from 'next-themes';
 import { Sun, Moon } from 'lucide-react';
 import { Button } from '@/components/ui/button';
 
 interface ThemeToggleProps {
-  theme: 'light' | 'dark';
-  onThemeChange: (theme: 'light' | 'dark') => void;
+  darkMode: boolean;
+  onThemeChange: (dark: boolean) => void;
 }
 
-export const ThemeToggle = ({ theme, onThemeChange }: ThemeToggleProps) => {
-  useEffect(() => {
-    document.documentElement.setAttribute('data-theme', theme);
-    setItem('theme', theme);
-  }, [theme]);
+export const ThemeToggle = ({ darkMode, onThemeChange }: ThemeToggleProps) => {
+  const { theme, setTheme } = useTheme();
 
   const toggleTheme = () => {
-    onThemeChange(theme === 'dark' ? 'light' : 'dark');
+    const newTheme = theme === 'dark' ? 'light' : 'dark';
+    setTheme(newTheme);
+    onThemeChange(newTheme === 'dark');
   };
 
   return (
@@ -24,7 +23,7 @@ export const ThemeToggle = ({ theme, onThemeChange }: ThemeToggleProps) => {
       className="neo-button-secondary"
       size="sm"
     >
-      {theme === 'dark' ? <Sun className="w-4 h-4" /> : <Moon className="w-4 h-4" />}
+      {darkMode ? <Sun className="w-4 h-4" /> : <Moon className="w-4 h-4" />}
     </Button>
   );
 };

--- a/src/hooks/useGlobalConfig.ts
+++ b/src/hooks/useGlobalConfig.ts
@@ -1,4 +1,5 @@
 import { useState, useEffect } from 'react';
+import { useTheme } from 'next-themes';
 import { getItem, setItem } from '@/utils/storage';
 import { GlobalConfig } from '@/types/dashboard';
 import { hexToHSL } from '@/lib/utils';
@@ -40,6 +41,7 @@ const getDefaultConfig = (): GlobalConfig => ({
 
 export const useGlobalConfig = () => {
   const [globalConfig, setGlobalConfig] = useState<GlobalConfig>(getDefaultConfig());
+  const { setTheme } = useTheme();
 
   useEffect(() => {
     (async () => {
@@ -72,18 +74,12 @@ export const useGlobalConfig = () => {
     });
   }, [globalConfig]);
 
-  // Update theme in IndexedDB when darkMode changes
+  // Update theme when darkMode changes
   useEffect(() => {
     const theme = globalConfig.darkMode ? 'dark' : 'light';
     setItem('theme', theme);
-    document.documentElement.setAttribute('data-theme', theme);
-    // Apply theme to document
-    if (globalConfig.darkMode) {
-      document.documentElement.classList.add('dark');
-    } else {
-      document.documentElement.classList.remove('dark');
-    }
-  }, [globalConfig.darkMode]);
+    setTheme(theme);
+  }, [globalConfig.darkMode, setTheme]);
 
   // Update accent color
   useEffect(() => {

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -1,6 +1,7 @@
 import { createRoot, Root } from 'react-dom/client';
 import App from './App.tsx';
 import { Toaster } from '@/components/ui/toaster';
+import { ThemeProvider } from 'next-themes';
 import './index.css';
 
 let root: Root | null = null;
@@ -13,10 +14,10 @@ function renderApp() {
   }
   if (!container.hasChildNodes()) {
     root.render(
-      <>
+      <ThemeProvider attribute="class" defaultTheme="system">
         <App />
         <Toaster />
-      </>
+      </ThemeProvider>
     );
   }
 }


### PR DESCRIPTION
## Summary
- wrap the app with `ThemeProvider`
- drive theme updates via `useTheme`
- update `ThemeToggle` to use next-themes API
- show a theme toggle in the dashboard header

## Testing
- `npm run lint` *(fails: @typescript-eslint/no-explicit-any and others)*
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68724974028c8325b2cdb44e2d12b8f3