### PR TITLE
Improve typings and add CI lint

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,17 @@
+name: CI
+on:
+  push:
+    branches: [main]
+  pull_request:
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+      - run: npm ci
+      - run: npm run lint
+      - run: npm test --if-present

--- a/package.json
+++ b/package.json
@@ -11,7 +11,8 @@
     "preview": "vite preview",
     "test": "vitest run",
     "build:server": "tsc -p server/tsconfig.json",
-    "server": "ts-node server/index.ts"
+    "server": "ts-node server/index.ts",
+    "pretest": "npm run lint"
   },
   "dependencies": {
     "@hookform/resolvers": "^5.1.1",

--- a/server/logger.ts
+++ b/server/logger.ts
@@ -1,4 +1,4 @@
 export const logger = {
-  info: (...args: any[]) => console.log('[info]', ...args),
-  error: (...args: any[]) => console.error('[error]', ...args)
+  info: (...args: unknown[]) => console.log('[info]', ...args),
+  error: (...args: unknown[]) => console.error('[error]', ...args)
 };

--- a/src/components/ConnectionManager.tsx
+++ b/src/components/ConnectionManager.tsx
@@ -1,11 +1,13 @@
-import React, { useState, useEffect } from 'react';
+import React, { useState, useEffect, useCallback } from 'react';
 import { Badge } from '@/components/ui/badge';
 import { Button } from '@/components/ui/button';
 import { Wifi, WifiOff, RefreshCw, Github, Server, Key } from 'lucide-react';
 import { useLogger } from '@/hooks/useLogger';
 
+import { ApiKey } from '@/types/dashboard';
+
 interface ConnectionManagerProps {
-  apiKeys: any[];
+  apiKeys: ApiKey[];
   compact?: boolean;
   checkInterval?: number;
 }
@@ -21,7 +23,7 @@ export const ConnectionManager: React.FC<ConnectionManagerProps> = ({ apiKeys, c
 
   const activeApiKeys = apiKeys.filter(k => k.isActive).length;
 
-  const handleRefresh = async () => {
+  const handleRefresh = useCallback(async () => {
     setIsRefreshing(true);
     
     try {
@@ -39,7 +41,7 @@ export const ConnectionManager: React.FC<ConnectionManagerProps> = ({ apiKeys, c
     } finally {
       setIsRefreshing(false);
     }
-  };
+  }, [activeApiKeys]);
 
   // Periodic server checks
   useEffect(() => {
@@ -50,7 +52,7 @@ export const ConnectionManager: React.FC<ConnectionManagerProps> = ({ apiKeys, c
     }, checkInterval);
     
     return () => clearInterval(interval);
-  }, [checkInterval, activeApiKeys]);
+  }, [checkInterval, activeApiKeys, handleRefresh]);
 
   if (compact) {
     return (

--- a/src/components/FeedActions.tsx
+++ b/src/components/FeedActions.tsx
@@ -97,7 +97,12 @@ export const FeedActions: React.FC<FeedActionsProps> = ({
             </div>
             <div>
               <Label>Event Type</Label>
-              <Select value={newAction.eventType} onValueChange={(value: any) => setNewAction({ ...newAction, eventType: value })}>
+              <Select
+                value={newAction.eventType}
+                onValueChange={(value: FeedAction['eventType']) =>
+                  setNewAction({ ...newAction, eventType: value })
+                }
+              >
                 <SelectTrigger className="neo-input">
                   <SelectValue />
                 </SelectTrigger>
@@ -113,7 +118,12 @@ export const FeedActions: React.FC<FeedActionsProps> = ({
             </div>
             <div>
               <Label>Action Type</Label>
-              <Select value={newAction.actionType} onValueChange={(value: any) => setNewAction({ ...newAction, actionType: value })}>
+              <Select
+                value={newAction.actionType}
+                onValueChange={(value: FeedAction['actionType']) =>
+                  setNewAction({ ...newAction, actionType: value })
+                }
+              >
                 <SelectTrigger className="neo-input">
                   <SelectValue />
                 </SelectTrigger>

--- a/src/hooks/useActivities.ts
+++ b/src/hooks/useActivities.ts
@@ -1,5 +1,5 @@
 import { useState } from 'react';
-import { ActivityItem } from '@/types/dashboard';
+import { ActivityItem, Repository, ApiKey } from '@/types/dashboard';
 import { useStatsPersistence } from './useStatsPersistence';
 import { createGitHubService } from '@/components/GitHubService';
 
@@ -9,8 +9,8 @@ export const useActivities = () => {
   const { mergeStats, updateStats, resetSessionStats } = useStatsPersistence();
 
   const fetchActivities = async (
-    repositories: any[],
-    apiKeys: any[],
+    repositories: Repository[],
+    apiKeys: ApiKey[],
     getKey: (id: string) => string | null,
     addRepoActivity?: (repoId: string, activity: Omit<ActivityItem, 'id'>) => void
   ) => {

--- a/src/hooks/useRepositories.ts
+++ b/src/hooks/useRepositories.ts
@@ -15,11 +15,11 @@ export const useRepositories = () => {
   useEffect(() => {
     let mounted = true;
     (async () => {
-      const savedRepos = await getItem<any>(REPOSITORIES_STORAGE_KEY);
+      const savedRepos = await getItem<Repository[]>(REPOSITORIES_STORAGE_KEY);
       if (!mounted || !savedRepos) return;
       try {
         const parsed = typeof savedRepos === 'string' ? JSON.parse(savedRepos) : savedRepos;
-        const repos = parsed.map((repo: any) => ({
+        const repos = parsed.map((repo: Repository) => ({
           ...repo,
           autoMergeOnClean: repo.autoMergeOnClean ?? repo.autoMergeEnabled ?? repo.enabled ?? true,
           autoMergeOnUnstable: repo.autoMergeOnUnstable ?? false,
@@ -32,7 +32,7 @@ export const useRepositories = () => {
             ...repo.recentPull,
             timestamp: new Date(repo.recentPull.timestamp)
           } : undefined,
-          activities: (repo.activities || []).map((activity: any) => ({
+          activities: (repo.activities || []).map((activity: ActivityItem) => ({
             ...activity,
             timestamp: new Date(activity.timestamp)
           }))
@@ -57,7 +57,7 @@ export const useRepositories = () => {
         variant: 'destructive'
       });
     });
-  }, [repositories]);
+  }, [repositories, toast]);
 
   function addRepositoryActivity(
     repoId: string,

--- a/src/hooks/useStatsPersistence.ts
+++ b/src/hooks/useStatsPersistence.ts
@@ -12,7 +12,7 @@ export const useStatsPersistence = () => {
 
   useEffect(() => {
     (async () => {
-      const savedStats = await getItem<any>(STATS_STORAGE_KEY);
+      const savedStats = await getItem<MergeStats>(STATS_STORAGE_KEY);
       if (savedStats) {
         try {
           const parsed = typeof savedStats === 'string' ? JSON.parse(savedStats) : savedStats;

--- a/src/hooks/useWatchModePersistence.ts
+++ b/src/hooks/useWatchModePersistence.ts
@@ -25,7 +25,7 @@ export const useWatchModePersistence = () => {
 
   useEffect(() => {
     (async () => {
-      const saved = await getItem<any>(WATCH_MODE_STORAGE_KEY);
+      const saved = await getItem<WatchModeState>(WATCH_MODE_STORAGE_KEY);
       if (saved) {
         try {
           const parsed = typeof saved === 'string' ? JSON.parse(saved) : saved;


### PR DESCRIPTION
## Summary
- add typings for some hooks and components
- replace `any` with safer types in logger and socket hook
- fix useEffect dependency for connection manager
- run eslint automatically in CI and before tests

## Testing
- `npm run lint` *(fails: 96 problems)*

------
https://chatgpt.com/codex/tasks/task_e_68741f875fe083259528301a4872616a