### PR TITLE
Add configuration sync over sockets

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,3 +22,4 @@ dist-ssr
 *.njsproj
 *.sln
 *.sw?
+server/config.json

--- a/README.md
+++ b/README.md
@@ -97,6 +97,15 @@ stored on the watcher and sent to newly subscribed sockets via the `repoCache`
 event. If GitHub requests fail, these cached values are returned so the UI can
 continue operating while offline.
 
+### Configuration sync
+
+After a client pairs with the server it should emit a `syncConfig` Socket.IO
+message containing its configuration (for example a list of protected branch
+patterns). The server stores this data per client in `server/config.json` and
+uses the settings when handling actions such as `fetchStrayBranches` and
+`deleteBranch`. The file persists across restarts so important settings remain
+available.
+
 ## Running the server and UI together
 
 1. Build the server TypeScript once:

--- a/server/config.ts
+++ b/server/config.ts
@@ -1,0 +1,34 @@
+import fs from 'fs/promises';
+import path from 'path';
+
+const STORAGE_PATH = process.env.CONFIG_STORAGE_PATH ||
+  path.join(process.cwd(), 'server', 'config.json');
+
+let configs: Record<string, any> = {};
+
+async function load() {
+  try {
+    const data = await fs.readFile(STORAGE_PATH, 'utf8');
+    configs = JSON.parse(data);
+  } catch {
+    configs = {};
+  }
+}
+
+async function save() {
+  await fs.writeFile(STORAGE_PATH, JSON.stringify(configs, null, 2));
+}
+
+// Load immediately
+load();
+
+export function getClientConfig(clientId: string) {
+  return configs[clientId] || {};
+}
+
+export async function setClientConfig(clientId: string, cfg: any) {
+  configs[clientId] = { ...configs[clientId], ...cfg };
+  await save();
+}
+
+export const __test = { load, save, configs, STORAGE_PATH };

--- a/src/hooks/useGlobalConfig.ts
+++ b/src/hooks/useGlobalConfig.ts
@@ -3,6 +3,7 @@ import { useTheme } from 'next-themes';
 import { getItem, setItem } from '@/utils/storage';
 import { GlobalConfig } from '@/types/dashboard';
 import { hexToHSL } from '@/lib/utils';
+import { socketService } from '@/services/SocketService';
 
 const GLOBAL_CONFIG_STORAGE_KEY = 'automerger-global-config';
 
@@ -92,6 +93,10 @@ export const useGlobalConfig = () => {
   const updateConfig = (updates: Partial<GlobalConfig>) => {
     setGlobalConfig(prev => ({ ...prev, ...updates }));
   };
+
+  useEffect(() => {
+    socketService.setConfigSupplier(() => globalConfig);
+  }, [globalConfig]);
 
   const resetConfig = () => {
     const defaultConfig = getDefaultConfig();


### PR DESCRIPTION
## Summary
- implement server side config storage and syncConfig event
- track per-client settings for deleting and listing branches
- send client config to server from SocketService and hook into useGlobalConfig
- document the new sync process
- test that synced config works

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68741f99a0108325a319a60417be0a94