### PR TITLE
Fix server import paths

### DIFF
--- a/server/index.ts
+++ b/server/index.ts
@@ -2,8 +2,8 @@
 import express from 'express';
 import http from 'http';
 import { Server } from 'socket.io';
-import { registerSocketHandlers } from './socketHandlers.ts';
-import { logger } from './logger.ts';
+import { registerSocketHandlers } from './socketHandlers.js';
+import { logger } from './logger.js';
 import { fileURLToPath } from 'url';
 
 export function startServer(port: number = Number(process.env.PORT) || 3001) {

--- a/server/socketHandlers.ts
+++ b/server/socketHandlers.ts
@@ -2,10 +2,10 @@
 import type { Server, Socket } from 'socket.io';
 import type express from 'express';
 import crypto from 'crypto';
-import { createGitHubService } from './github.ts';
-import { subscribeRepo, unsubscribeRepo, getWatcher } from './watchers.ts';
-import { logger } from './logger.ts';
-import { getClientConfig, setClientConfig } from './config.ts';
+import { createGitHubService } from './github.js';
+import { subscribeRepo, unsubscribeRepo, getWatcher } from './watchers.js';
+import { logger } from './logger.js';
+import { getClientConfig, setClientConfig } from './config.js';
 
 const pairedClients = new Set<string>();
 const pendingPairings = new Map<string, { socket: Socket; clientId: string | null; expiry: number }>();

--- a/server/watchers.ts
+++ b/server/watchers.ts
@@ -1,7 +1,7 @@
 // @ts-nocheck
-import { createGitHubService } from './github.ts';
-import { WebhookService } from './webhooks.ts';
-import { logger } from './logger.ts';
+import { createGitHubService } from './github.js';
+import { WebhookService } from './webhooks.js';
+import { logger } from './logger.js';
 
 const DEFAULT_INTERVAL = parseInt(process.env.POLL_INTERVAL_MS || '60000', 10);
 const CACHE_TTL = parseInt(process.env.CACHE_TTL_MS || '300000', 10);

--- a/server/webhooks.ts
+++ b/server/webhooks.ts
@@ -2,7 +2,7 @@
 import fs from 'fs/promises';
 import path from 'path';
 import crypto from 'crypto';
-import { logger } from './logger.ts';
+import { logger } from './logger.js';
 
 const STORAGE_PATH = process.env.WEBHOOK_STORAGE_PATH ||
   path.join(process.cwd(), 'server', 'webhooks.json');


### PR DESCRIPTION
## Summary
- fix file extensions for server imports so compiled output runs

## Testing
- `npm test` *(fails: lint errors)*
- `npm run build:server`
- `node server/dist/index.js`

------
https://chatgpt.com/codex/tasks/task_e_6875156eb38c8325afd05d41c99da9e9