### PR TITLE
Improve watcher caching and tests

### DIFF
--- a/src/__tests__/GitHubService.test.ts
+++ b/src/__tests__/GitHubService.test.ts
@@ -1,23 +1,24 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 
-vi.mock('../services/SocketService', () => {
+const requestMock = vi.fn();
+vi.mock('@/services/SocketService', () => {
   return {
     getSocketService: () => ({
-      request: vi.fn()
+      request: requestMock
     })
   };
 });
 
-import { getSocketService } from '../services/SocketService';
+import { getSocketService } from '@/services/SocketService';
 import { GitHubService } from '../components/GitHubService';
 
 let service: GitHubService;
 let socketService: any;
 
 beforeEach(() => {
+  vi.clearAllMocks();
   service = new GitHubService('token');
   socketService = getSocketService();
-  vi.clearAllMocks();
 });
 
 describe('GitHubService', () => {


### PR DESCRIPTION
## Summary
- extend watcher state to store PRs, stray branches, and activity
- send cached watcher info in `subscribeRepo`
- fallback to cached data in socket handlers when GitHub requests fail
- document caching behaviour
- fix GitHubService tests

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68751ba6f1c083258ec6f0499c88beb3