### PR TITLE
Fix theme() quoting in sidebar and styles

### DIFF
--- a/src/components/StatsCards.tsx
+++ b/src/components/StatsCards.tsx
@@ -63,7 +63,7 @@ export const StatsCards: React.FC<StatsCardsProps> = ({ repositories, apiKeys, m
       {stats.map((stat, index) => (
         <Card
           key={index}
-          className={`nb-card ${stat.color} p-3 min-w-[110px] flex-shrink-0 shadow-[3px_3px_0_theme(colors.foreground)]`}
+          className={`nb-card ${stat.color} p-3 min-w-[110px] flex-shrink-0 shadow-[3px_3px_0_theme('colors.foreground')]`}
         >
           <div className="text-center">
             <div className="text-black dark:text-white font-black text-base mb-1">

--- a/src/components/ui/sidebar.tsx
+++ b/src/components/ui/sidebar.tsx
@@ -226,7 +226,7 @@ const Sidebar = React.forwardRef<
             "group-data-[collapsible=offcanvas]:w-0",
             "group-data-[side=right]:rotate-180",
             variant === "floating" || variant === "inset"
-              ? "group-data-[collapsible=icon]:w-[calc(var(--sidebar-width-icon)_+_theme(spacing.4))]"
+              ? "group-data-[collapsible=icon]:w-[calc(var(--sidebar-width-icon)_+_theme('spacing.4'))]"
               : "group-data-[collapsible=icon]:w-[--sidebar-width-icon]"
           )}
         />
@@ -238,7 +238,7 @@ const Sidebar = React.forwardRef<
               : "right-0 group-data-[collapsible=offcanvas]:right-[calc(var(--sidebar-width)*-1)]",
             // Adjust the padding for floating and inset variants.
             variant === "floating" || variant === "inset"
-              ? "p-2 group-data-[collapsible=icon]:w-[calc(var(--sidebar-width-icon)_+_theme(spacing.4)_+2px)]"
+              ? "p-2 group-data-[collapsible=icon]:w-[calc(var(--sidebar-width-icon)_+_theme('spacing.4')_+2px)]"
               : "group-data-[collapsible=icon]:w-[--sidebar-width-icon] group-data-[side=left]:border-r group-data-[side=right]:border-l",
             className
           )}
@@ -321,7 +321,7 @@ const SidebarInset = React.forwardRef<
       ref={ref}
       className={cn(
         "relative flex min-h-svh flex-1 flex-col bg-background",
-        "peer-data-[variant=inset]:min-h-[calc(100svh-theme(spacing.4))] md:peer-data-[variant=inset]:m-2 md:peer-data-[state=collapsed]:peer-data-[variant=inset]:ml-2 md:peer-data-[variant=inset]:ml-0 md:peer-data-[variant=inset]:rounded-xl md:peer-data-[variant=inset]:shadow",
+        "peer-data-[variant=inset]:min-h-[calc(100svh - theme('spacing.4'))] md:peer-data-[variant=inset]:m-2 md:peer-data-[state=collapsed]:peer-data-[variant=inset]:ml-2 md:peer-data-[variant=inset]:ml-0 md:peer-data-[variant=inset]:rounded-xl md:peer-data-[variant=inset]:shadow",
         className
       )}
       {...props}

--- a/src/index.css
+++ b/src/index.css
@@ -101,7 +101,7 @@
 
 @layer components {
   .nb-card {
-    @apply bg-card border-4 border-foreground shadow-[8px_8px_0px_0px_theme(colors.foreground)];
+    @apply bg-card border-4 border-foreground shadow-[8px_8px_0px_0px_theme('colors.foreground')];
 
   }
 
@@ -122,22 +122,22 @@
   .dark .nb-card.nb-red { @apply text-white border-2 border-gray-600; }
   
   .nb-button {
-    @apply bg-primary border-4 border-foreground shadow-[4px_4px_0px_0px_theme(colors.foreground)]
-           hover:shadow-[2px_2px_0px_0px_theme(colors.foreground)]
+    @apply bg-primary border-4 border-foreground shadow-[4px_4px_0px_0px_theme('colors.foreground')]
+           hover:shadow-[2px_2px_0px_0px_theme('colors.foreground')]
            hover:translate-x-[2px] hover:translate-y-[2px]
            transition-all duration-150 font-black uppercase tracking-wider;
   }
   
   .nb-button-secondary {
-    @apply bg-secondary border-4 border-foreground shadow-[4px_4px_0px_0px_theme(colors.foreground)]
-           hover:shadow-[2px_2px_0px_0px_theme(colors.foreground)]
+    @apply bg-secondary border-4 border-foreground shadow-[4px_4px_0px_0px_theme('colors.foreground')]
+           hover:shadow-[2px_2px_0px_0px_theme('colors.foreground')]
            hover:translate-x-[2px] hover:translate-y-[2px]
            transition-all duration-150 font-black uppercase tracking-wider;
   }
   
   .nb-input {
-    @apply bg-background border-4 border-foreground shadow-[4px_4px_0px_0px_theme(colors.foreground)]
-           focus:shadow-[2px_2px_0px_0px_theme(colors.foreground)]
+    @apply bg-background border-4 border-foreground shadow-[4px_4px_0px_0px_theme('colors.foreground')]
+           focus:shadow-[2px_2px_0px_0px_theme('colors.foreground')]
            focus:translate-x-[2px] focus:translate-y-[2px]
            transition-all duration-150 font-bold;
   }


### PR DESCRIPTION
## Summary
- correct Tailwind `theme()` function usage
- quote theme path in StatsCards and global styles

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68753be86d2c8325a5452f25fbe79e2f