### PR TITLE
Ensure config loaded before use

### DIFF
--- a/server/config.ts
+++ b/server/config.ts
@@ -1,4 +1,4 @@
-import fs from 'fs/promises';
+import fs from 'fs';
 import path from 'path';
 
 const STORAGE_PATH = process.env.CONFIG_STORAGE_PATH ||
@@ -6,21 +6,25 @@ const STORAGE_PATH = process.env.CONFIG_STORAGE_PATH ||
 
 let configs: Record<string, any> = {};
 
-async function load() {
+function loadSync() {
   try {
-    const data = await fs.readFile(STORAGE_PATH, 'utf8');
+    const data = fs.readFileSync(STORAGE_PATH, 'utf8');
     configs = JSON.parse(data);
   } catch {
     configs = {};
   }
 }
 
-async function save() {
-  await fs.writeFile(STORAGE_PATH, JSON.stringify(configs, null, 2));
+async function load() {
+  loadSync();
 }
 
-// Load immediately
-load();
+async function save() {
+  await fs.promises.writeFile(STORAGE_PATH, JSON.stringify(configs, null, 2));
+}
+
+// Load immediately and synchronously so configs are ready
+loadSync();
 
 export function getClientConfig(clientId: string) {
   return configs[clientId] || {};


### PR DESCRIPTION
## Summary
- load configuration synchronously so `getClientConfig` always has data ready

## Testing
- `npm test`
- `npm run build:server`


------
https://chatgpt.com/codex/tasks/task_e_6877b4fac8d88325a038917c504a392d