### PR TITLE
Replace console.error with logger

### DIFF
--- a/src/hooks/useApiKeys.ts
+++ b/src/hooks/useApiKeys.ts
@@ -10,7 +10,7 @@ const API_KEYS_STORAGE_KEY = 'automerger-api-keys';
 
 export const useApiKeys = () => {
   const { toast } = useToast();
-  const { logInfo } = useLogger();
+  const { logInfo, logError } = useLogger();
   
   const [apiKeys, setApiKeys] = useState<ApiKey[]>([]);
 
@@ -28,7 +28,7 @@ export const useApiKeys = () => {
           }))
         );
       } catch (error) {
-        console.error('Error parsing saved API keys:', error);
+        logError('api-key', 'Error parsing saved API keys', error);
       }
     })();
   }, []);
@@ -44,9 +44,9 @@ export const useApiKeys = () => {
 
   // Persist API keys to IndexedDB whenever they change
   useEffect(() => {
-    setItem(API_KEYS_STORAGE_KEY, apiKeys).catch(err => {
-      console.error('Error saving API keys:', err);
-    });
+      setItem(API_KEYS_STORAGE_KEY, apiKeys).catch(err => {
+        logError('api-key', 'Error saving API keys', err);
+      });
   }, [apiKeys]);
 
   const unlock = async () => {
@@ -119,10 +119,10 @@ export const useApiKeys = () => {
         }
       });
       return response.ok;
-    } catch (error) {
-      console.error('API key validation failed:', error);
-      return false;
-    }
+      } catch (error) {
+        logError('api-key', 'API key validation failed', error);
+        return false;
+      }
   };
 
   const addApiKey = async (name: string, key: string) => {

--- a/src/hooks/useRepositories.ts
+++ b/src/hooks/useRepositories.ts
@@ -9,7 +9,7 @@ const REPOSITORIES_STORAGE_KEY = 'automerger-repositories';
 
 export const useRepositories = () => {
   const { toast } = useToast();
-  const { logInfo } = useLogger();
+  const { logInfo, logError } = useLogger();
   
   const [repositories, setRepositories] = useState<Repository[]>([]);
 
@@ -40,7 +40,7 @@ export const useRepositories = () => {
         }));
         setRepositories(repos);
       } catch (error) {
-        console.error('Error parsing saved repositories:', error);
+        logError('repository', 'Error parsing saved repositories', error);
       }
     })();
     return () => {
@@ -50,14 +50,14 @@ export const useRepositories = () => {
 
   // Persist repositories to IndexedDB whenever they change
   useEffect(() => {
-    setItem(REPOSITORIES_STORAGE_KEY, repositories).catch(error => {
-      console.error('Error saving repositories:', error);
-      toast({
-        title: 'Storage error',
-        description: 'Unable to save repository data to IndexedDB.',
-        variant: 'destructive'
+      setItem(REPOSITORIES_STORAGE_KEY, repositories).catch(error => {
+        logError('repository', 'Error saving repositories', error);
+        toast({
+          title: 'Storage error',
+          description: 'Unable to save repository data to IndexedDB.',
+          variant: 'destructive'
+        });
       });
-    });
   }, [repositories, toast]);
 
   function addRepositoryActivity(


### PR DESCRIPTION
## Summary
- use `logError` from `useLogger` inside `useApiKeys`
- use `logError` from `useLogger` inside `useRepositories`

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6877b64c122883258779c337c069ba3f