### PR TITLE
Improve webhook failure messages

### DIFF
--- a/server/webhooks.ts
+++ b/server/webhooks.ts
@@ -58,7 +58,7 @@ export class WebhookService {
         },
         body: JSON.stringify(payload)
       });
-      if (!res.ok) throw new Error(`HTTP ${res.status}`);
+      if (!res.ok) throw new Error(`HTTP ${res.status} ${res.statusText}`);
       await this.saveWebhook({ ...webhook, lastTriggered: new Date().toISOString() });
       return { success: true };
     } catch (err) {


### PR DESCRIPTION
## Summary
- include response status text in thrown errors for webhook requests

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6877c533862483259036c13a878c05cc