### PR TITLE
Remove unused logWarn variable

### DIFF
--- a/src/components/ConnectionManager.tsx
+++ b/src/components/ConnectionManager.tsx
@@ -19,7 +19,7 @@ export const ConnectionManager: React.FC<ConnectionManagerProps> = ({ apiKeys, c
   const [latency, setLatency] = useState(0);
   const [isRefreshing, setIsRefreshing] = useState(false);
 
-  const { logInfo, logWarn } = useLogger();
+  const { logInfo } = useLogger();
 
   const activeApiKeys = apiKeys.filter(k => k.isActive).length;
 
@@ -103,3 +103,4 @@ export const ConnectionManager: React.FC<ConnectionManagerProps> = ({ apiKeys, c
     </div>
   );
 };
+


### PR DESCRIPTION
## Summary
- trim unused logWarn from `ConnectionManager`

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6877c8318eac83259f39112a2e961638