### PR TITLE
Include status text in webhook error

### DIFF
--- a/server/webhooks.ts
+++ b/server/webhooks.ts
@@ -58,7 +58,7 @@ export class WebhookService {
         },
         body: JSON.stringify(payload)
       });
-      if (!res.ok) throw new Error(`HTTP ${res.status} ${res.statusText}`);
+      if (!res.ok) throw new Error(`HTTP ${res.status}: ${res.statusText}`);
       await this.saveWebhook({ ...webhook, lastTriggered: new Date().toISOString() });
       return { success: true };
     } catch (err) {


### PR DESCRIPTION
## Summary
- improve error detail in `WebhookService.triggerWebhook`

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6877cc7def548325b0501b62bf5162ca