### PR TITLE
Ensure server config load completed before use

### DIFF
--- a/server/__tests__/config-storage.test.ts
+++ b/server/__tests__/config-storage.test.ts
@@ -10,6 +10,7 @@ let mod: typeof import('../config.js');
 async function loadModule() {
   vi.resetModules();
   mod = await import('../config.ts');
+  await mod.loadPromise;
 }
 
 beforeEach(async () => {

--- a/server/__tests__/config.test.ts
+++ b/server/__tests__/config.test.ts
@@ -10,6 +10,7 @@ let mod: typeof import('../config.js');
 async function loadModule() {
   vi.resetModules();
   mod = await import('../config.ts');
+  await mod.loadPromise;
 }
 
 beforeEach(async () => {

--- a/server/__tests__/socketHandlers.test.ts
+++ b/server/__tests__/socketHandlers.test.ts
@@ -4,6 +4,9 @@ import http from 'http';
 import { Server } from 'socket.io';
 import { io as Client } from 'socket.io-client';
 import supertest from 'supertest';
+import fs from 'fs';
+import path from 'path';
+import os from 'os';
 
 import { registerSocketHandlers } from '../socketHandlers.ts';
 
@@ -17,8 +20,17 @@ let ioServer: Server;
 let httpServer: http.Server;
 let request: supertest.SuperTest<supertest.Test>;
 let client: ReturnType<typeof Client>;
+let tmpDir: string;
+let configPath: string;
 
 beforeEach(async () => {
+  tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'cfg-'));
+  configPath = path.join(tmpDir, 'config.json');
+  fs.writeFileSync(configPath, '{}');
+  process.env.CONFIG_STORAGE_PATH = configPath;
+  const cfgMod = await import('../config.ts');
+  await cfgMod.loadPromise;
+
   const app = express();
   app.use(express.json());
   httpServer = http.createServer(app);
@@ -40,6 +52,8 @@ afterEach(() => {
   client.disconnect();
   ioServer.close();
   httpServer.close();
+  delete process.env.CONFIG_STORAGE_PATH;
+  fs.rmSync(tmpDir, { recursive: true, force: true });
 });
 
 describe('socket handlers', () => {
@@ -102,4 +116,23 @@ describe('socket handlers', () => {
     expect(delResp).toEqual({ ok: false, error: 'branch protected' });
     expect(svcMock.deleteBranch).not.toHaveBeenCalled();
   }, 10000);
+
+  it('loads config before handlers run', async () => {
+    fs.writeFileSync(configPath, JSON.stringify({ c1: { protectedBranches: ['keep'] } }, null, 2));
+    const cfgMod = await import('../config.ts');
+    await cfgMod.loadPromise;
+
+    svcMock.fetchStrayBranches.mockResolvedValue(['keep', 'remove']);
+
+    const token = await new Promise<string>(resolve => {
+      client.once('pair_token', ({ token }) => resolve(token));
+      client.emit('pair_request', { clientId: 'c1' });
+    });
+    await request.post(`/pairings/${token}/approve`).send({ secret: 'secret' });
+
+    const resp = await new Promise<any>(resolve => {
+      client.emit('fetchStrayBranches', { token: 't', owner: 'o', repo: 'r' }, resolve);
+    });
+    expect(resp).toEqual({ ok: true, data: ['remove'] });
+  });
 });

--- a/server/config.ts
+++ b/server/config.ts
@@ -1,4 +1,4 @@
-import fs from 'fs';
+import fs from 'fs/promises';
 import path from 'path';
 
 const STORAGE_PATH = process.env.CONFIG_STORAGE_PATH ||
@@ -6,25 +6,20 @@ const STORAGE_PATH = process.env.CONFIG_STORAGE_PATH ||
 
 let configs: Record<string, any> = {};
 
-function loadSync() {
+export async function load() {
   try {
-    const data = fs.readFileSync(STORAGE_PATH, 'utf8');
+    const data = await fs.readFile(STORAGE_PATH, 'utf8');
     configs = JSON.parse(data);
   } catch {
     configs = {};
   }
 }
 
-async function load() {
-  loadSync();
-}
+export const loadPromise = load();
 
 async function save() {
-  await fs.promises.writeFile(STORAGE_PATH, JSON.stringify(configs, null, 2));
+  await fs.writeFile(STORAGE_PATH, JSON.stringify(configs, null, 2));
 }
-
-// Load immediately and synchronously so configs are ready
-loadSync();
 
 export function getClientConfig(clientId: string) {
   return configs[clientId] || {};
@@ -35,4 +30,4 @@ export async function setClientConfig(clientId: string, cfg: any) {
   await save();
 }
 
-export const __test = { load, save, configs, STORAGE_PATH };
+export const __test = { load, loadPromise, save, configs, STORAGE_PATH };

--- a/server/index.ts
+++ b/server/index.ts
@@ -4,9 +4,11 @@ import http from 'http';
 import { Server } from 'socket.io';
 import { registerSocketHandlers } from './socketHandlers.js';
 import { logger } from './logger.js';
+import { loadPromise } from './config.js';
 import { fileURLToPath } from 'url';
 
-export function startServer(port: number = Number(process.env.PORT) || 3001) {
+export async function startServer(port: number = Number(process.env.PORT) || 3001) {
+  await loadPromise;
   const app = express();
   app.use(express.json());
 


### PR DESCRIPTION
## Summary
- load server config asynchronously and export `loadPromise`
- await `loadPromise` during server startup
- adjust config unit tests for `loadPromise`
- update socket handler tests and add coverage for startup config

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6877cc88b0d48325a59842a983eb869b