### PR TITLE
Centralize pattern matching

### DIFF
--- a/server/github.ts
+++ b/server/github.ts
@@ -1,5 +1,6 @@
 // @ts-nocheck
 import { Octokit } from '@octokit/rest';
+import { matchesPattern } from './utils/patterns.js';
 
 const STRAY_CACHE_TTL = parseInt(
   process.env.STRAY_BRANCH_CACHE_TTL_MS || '300000',
@@ -88,11 +89,6 @@ export function createGitHubService(token) {
     },
 
     async deleteBranch(owner, repo, branch, allowedPatterns = []) {
-      const matchesPattern = (value, pattern) => {
-        const escapeRegex = s => s.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
-        const regex = new RegExp('^' + pattern.split('*').map(escapeRegex).join('.*') + '$');
-        return regex.test(value);
-      };
 
       const key = `${owner}/${repo}`;
       cleanupStrayCache();

--- a/server/socketHandlers.ts
+++ b/server/socketHandlers.ts
@@ -6,6 +6,7 @@ import { createGitHubService } from './github.js';
 import { subscribeRepo, unsubscribeRepo, getWatcher } from './watchers.js';
 import { logger } from './logger.js';
 import { getClientConfig, setClientConfig } from './config.js';
+import { matchesPattern } from './utils/patterns.js';
 
 const pairedClients = new Set<string>();
 const pendingPairings = new Map<string, { socket: Socket; clientId: string | null; expiry: number }>();
@@ -20,12 +21,6 @@ function requirePaired(socket: Socket, cb?: (arg0: any) => void) {
     return false;
   }
   return true;
-}
-
-function matchesPattern(value, pattern) {
-  const escapeRegex = s => s.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
-  const regex = new RegExp('^' + pattern.split('*').map(escapeRegex).join('.*') + '$');
-  return regex.test(value);
 }
 
 function cleanupPairings() {

--- a/server/utils/patterns.ts
+++ b/server/utils/patterns.ts
@@ -1,0 +1,5 @@
+export function matchesPattern(value: string, pattern: string): boolean {
+  const escapeRegex = (s: string) => s.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+  const regex = new RegExp('^' + pattern.split('*').map(escapeRegex).join('.*') + '$');
+  return regex.test(value);
+}

--- a/server/watchers.ts
+++ b/server/watchers.ts
@@ -2,18 +2,13 @@
 import { createGitHubService } from './github.js';
 import { WebhookService } from './webhooks.js';
 import { logger } from './logger.js';
+import { matchesPattern } from './utils/patterns.js';
 
 const DEFAULT_INTERVAL = parseInt(process.env.POLL_INTERVAL_MS || '60000', 10);
 const CACHE_TTL = parseInt(process.env.CACHE_TTL_MS || '300000', 10);
 
 const watchers = new Map();
 const repoCache = new Map();
-
-function matchesPattern(value, pattern) {
-  const escapeRegex = s => s.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
-  const regex = new RegExp('^' + pattern.split('*').map(escapeRegex).join('.*') + '$');
-  return regex.test(value);
-}
 
 function cleanCache() {
   const now = Date.now();


### PR DESCRIPTION
## Summary
- add a `matchesPattern` helper in `server/utils/patterns.ts`
- reuse the helper in GitHub, socket handler and watcher modules

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6877d23c71688325ba11db48dd9560cb