### PR TITLE
Fix red buttons

### DIFF
--- a/src/components/ApiKeyCard.tsx
+++ b/src/components/ApiKeyCard.tsx
@@ -99,7 +99,6 @@ export const ApiKeyCard: React.FC<ApiKeyCardProps> = ({
               variant="destructive"
               size="sm"
               onClick={handleDelete}
-              className="nb-button bg-red-500 hover:bg-red-600"
             >
               <Trash2 className="w-4 h-4" />
             </Button>

--- a/src/components/FeedActions.tsx
+++ b/src/components/FeedActions.tsx
@@ -192,7 +192,6 @@ export const FeedActions: React.FC<FeedActionsProps> = ({
                     variant="destructive"
                     size="sm"
                     onClick={() => deleteAction(action.id)}
-                    className="nb-button bg-red-500 hover:bg-red-600"
                   >
                     <Trash2 className="w-4 h-4" />
                   </Button>

--- a/src/components/GlobalConfiguration.tsx
+++ b/src/components/GlobalConfiguration.tsx
@@ -632,12 +632,12 @@ export const GlobalConfiguration: React.FC<GlobalConfigurationProps> = ({
               />
               <div className="flex justify-end">
               <Button
+                variant="destructive"
                 size="sm"
                 onClick={() => {
                   clearWatchModeState();
                   toast({ title: 'Watch mode data cleared' });
                 }}
-                className="nb-button bg-red-500 hover:bg-red-600"
               >
                 <Trash2 className="w-4 h-4 mr-2" />
                 Clear Watch Mode

--- a/src/components/WatchMode.tsx
+++ b/src/components/WatchMode.tsx
@@ -447,7 +447,7 @@ export const WatchMode: React.FC<WatchModeProps> = ({ repositories, apiKeys, get
                                     <Button
                                       onClick={() => handleClose(repo, pr.number)}
                                       size="sm"
-                                      className="nb-button nb-red"
+                                      variant="destructive"
                                     >
                                       <XCircle className="w-3 h-3 mr-1" />
                                       Close
@@ -528,7 +528,6 @@ export const WatchMode: React.FC<WatchModeProps> = ({ repositories, apiKeys, get
                                   </span>
                                   <Button
                                     size="sm"
-                                    className="nb-button nb-red"
                                     variant="destructive"
                                     onClick={() => {
                                       if (globalConfig.confirmBranchDeletion) {

--- a/src/components/ui/confirmation-dialog.tsx
+++ b/src/components/ui/confirmation-dialog.tsx
@@ -9,6 +9,7 @@ import {
   AlertDialogHeader,
   AlertDialogTitle,
 } from '@/components/ui/alert-dialog';
+import { buttonVariants } from '@/components/ui/button';
 
 interface ConfirmationDialogProps {
   open: boolean;
@@ -42,9 +43,9 @@ export const ConfirmationDialog: React.FC<ConfirmationDialogProps> = ({
           <AlertDialogCancel className="nb-button-secondary">
             {cancelText}
           </AlertDialogCancel>
-          <AlertDialogAction 
+          <AlertDialogAction
             onClick={onConfirm}
-            className={variant === 'destructive' ? 'nb-button bg-red-500 hover:bg-red-600' : 'nb-button'}
+            className={buttonVariants({ variant })}
           >
             {confirmText}
           </AlertDialogAction>


### PR DESCRIPTION
## Summary
- use `variant="destructive"` for red buttons
- use `buttonVariants` in confirmation dialog

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_687a35084b608325b09663e7f9bbfe1b