### PR TITLE
Refine empty state styles

### DIFF
--- a/src/components/ApiKeyCard.tsx
+++ b/src/components/ApiKeyCard.tsx
@@ -47,7 +47,7 @@ export const ApiKeyCard: React.FC<ApiKeyCardProps> = ({
             </div>
             <div>
               <div className="flex items-center gap-2">
-                <h3 className="font-black text-lg">{apiKey.name}</h3>
+                <h3 className="font-semibold text-lg">{apiKey.name}</h3>
                 {apiKey.encrypted && (
                   <Badge variant="secondary" className="nb-card nb-purple text-black font-bold">
                     <Shield className="w-3 h-3 mr-1" />
@@ -75,7 +75,7 @@ export const ApiKeyCard: React.FC<ApiKeyCardProps> = ({
                   </Badge>
                 )}
               </div>
-              <p className="text-sm text-muted-foreground font-bold">
+              <p className="text-sm text-muted-foreground">
                 Created: {apiKey.created.toLocaleDateString()}
                 {apiKey.lastUsed && ` • Last used: ${apiKey.lastUsed.toLocaleDateString()}`}
               </p>

--- a/src/components/Dashboard.tsx
+++ b/src/components/Dashboard.tsx
@@ -136,7 +136,7 @@ export const Dashboard: React.FC = () => {
               </div>
               <div>
                 <h1 className="text-3xl font-black text-shadow">AutoMerger Dashboard</h1>
-                <p className="text-muted-foreground font-bold">Automated pull request management system</p>
+                <p className="text-muted-foreground">Automated pull request management system</p>
               </div>
             </div>
             <div className="flex items-center gap-3">

--- a/src/components/DashboardHeader.tsx
+++ b/src/components/DashboardHeader.tsx
@@ -22,7 +22,7 @@ export const DashboardHeader: React.FC<DashboardHeaderProps> = ({ apiKeys = [], 
             </div>
             <div>
               <CardTitle className="text-4xl font-black">AutoMerger Dashboard</CardTitle>
-              <p className="text-muted-foreground font-bold">Automated pull request management system</p>
+              <p className="text-muted-foreground">Automated pull request management system</p>
             </div>
           </div>
           <div className="flex items-center gap-2">

--- a/src/components/DetailedStatistics.tsx
+++ b/src/components/DetailedStatistics.tsx
@@ -33,19 +33,19 @@ export const DetailedStatistics: React.FC<DetailedStatisticsProps> = ({ reposito
           <div className="grid grid-cols-2 md:grid-cols-4 gap-6">
             <div className="text-center">
               <div className="text-3xl font-black text-green-600">{realStats.overall.totalMerges}</div>
-              <div className="text-sm font-bold text-muted-foreground">Total Merges</div>
+              <div className="text-sm text-muted-foreground">Total Merges</div>
             </div>
             <div className="text-center">
               <div className="text-3xl font-black text-blue-600">{realStats.overall.totalPullRequests}</div>
-              <div className="text-sm font-bold text-muted-foreground">Pull Requests</div>
+              <div className="text-sm text-muted-foreground">Pull Requests</div>
             </div>
             <div className="text-center">
               <div className="text-3xl font-black text-purple-600">{realStats.overall.avgSuccessRate.toFixed(1)}%</div>
-              <div className="text-sm font-bold text-muted-foreground">Success Rate</div>
+              <div className="text-sm text-muted-foreground">Success Rate</div>
             </div>
             <div className="text-center">
               <div className="text-3xl font-black text-orange-600">{realStats.overall.totalAlerts}</div>
-              <div className="text-sm font-bold text-muted-foreground">Alerts</div>
+              <div className="text-sm text-muted-foreground">Alerts</div>
             </div>
           </div>
         </CardContent>
@@ -118,7 +118,7 @@ export const DetailedStatistics: React.FC<DetailedStatisticsProps> = ({ reposito
           {Object.entries(realStats.repositories).map(([repoId, stats]) => (
             <div key={repoId} className="nb-card p-4 space-y-3">
               <div className="flex items-center justify-between">
-                <h3 className="font-black text-lg">{stats.name}</h3>
+                <h3 className="font-semibold text-lg">{stats.name}</h3>
                 <div className="flex items-center gap-2">
                   <Badge className="nb-card nb-green text-black font-bold">
                     {getSuccessRate(stats.successes, stats.merges)}% success
@@ -131,29 +131,29 @@ export const DetailedStatistics: React.FC<DetailedStatisticsProps> = ({ reposito
               
               <div className="grid grid-cols-2 md:grid-cols-5 gap-4 text-sm">
                 <div>
-                  <div className="font-bold text-muted-foreground">Merges</div>
+                  <div className="text-muted-foreground">Merges</div>
                   <div className="text-lg font-black">{stats.merges}</div>
                 </div>
                 <div>
-                  <div className="font-bold text-muted-foreground">Success</div>
+                  <div className="text-muted-foreground">Success</div>
                   <div className="text-lg font-black text-green-600">{stats.successes}</div>
                 </div>
                 <div>
-                  <div className="font-bold text-muted-foreground">Failures</div>
+                  <div className="text-muted-foreground">Failures</div>
                   <div className="text-lg font-black text-red-600">{stats.failures}</div>
                 </div>
                 <div>
-                  <div className="font-bold text-muted-foreground">Avg Time</div>
+                  <div className="text-muted-foreground">Avg Time</div>
                   <div className="text-lg font-black">{stats.avgMergeTime}min</div>
                 </div>
                 <div>
-                  <div className="font-bold text-muted-foreground">Alerts</div>
+                  <div className="text-muted-foreground">Alerts</div>
                   <div className="text-lg font-black text-orange-600">{stats.alerts}</div>
                 </div>
               </div>
 
               <div>
-                <div className="flex justify-between text-sm font-bold mb-2">
+                <div className="flex justify-between text-sm font-semibold mb-2">
                   <span>Success Rate</span>
                   <span>{getSuccessRate(stats.successes, stats.merges)}%</span>
                 </div>

--- a/src/components/FeedActions.tsx
+++ b/src/components/FeedActions.tsx
@@ -169,7 +169,7 @@ export const FeedActions: React.FC<FeedActionsProps> = ({
                   </div>
                   <div>
                     <div className="flex items-center gap-2">
-                      <h3 className="font-black text-lg">{action.name}</h3>
+                      <h3 className="font-semibold text-lg">{action.name}</h3>
                       <Badge variant="secondary" className={`nb-card ${getEventColor(action.eventType)} text-black font-bold`}>
                         {action.eventType}
                       </Badge>
@@ -177,7 +177,7 @@ export const FeedActions: React.FC<FeedActionsProps> = ({
                         {action.actionType}
                       </Badge>
                     </div>
-                    <p className="text-sm text-muted-foreground font-bold truncate max-w-md">
+                    <p className="text-sm text-muted-foreground truncate max-w-md">
                       {action.endpoint}
                     </p>
                   </div>

--- a/src/components/GlobalConfiguration.tsx
+++ b/src/components/GlobalConfiguration.tsx
@@ -381,7 +381,7 @@ export const GlobalConfiguration: React.FC<GlobalConfigurationProps> = ({
       <CardContent className="space-y-6">
         {/* Approval Settings */}
         <div className="space-y-4">
-          <h4 className="font-black text-lg">Approval Settings</h4>
+          <h4 className="font-semibold text-lg">Approval Settings</h4>
           <div className="space-y-4">
             <ConfigToggle
               id="requireApproval"
@@ -406,7 +406,7 @@ export const GlobalConfiguration: React.FC<GlobalConfigurationProps> = ({
 
         {/* Default Branch Patterns */}
         <div className="space-y-3">
-          <h4 className="font-black text-lg">Default Branch Patterns</h4>
+          <h4 className="font-semibold text-lg">Default Branch Patterns</h4>
           <EditableList
             items={config.defaultBranchPatterns}
             reorderable
@@ -418,7 +418,7 @@ export const GlobalConfiguration: React.FC<GlobalConfigurationProps> = ({
 
         {/* Default Allowed Users */}
         <div className="space-y-3">
-          <h4 className="font-black text-lg">Default Allowed Users</h4>
+          <h4 className="font-semibold text-lg">Default Allowed Users</h4>
           <EditableList
             items={config.defaultAllowedUsers}
             reorderable
@@ -430,7 +430,7 @@ export const GlobalConfiguration: React.FC<GlobalConfigurationProps> = ({
 
         {/* Protected Branches */}
         <div className="space-y-3">
-          <h4 className="font-black text-lg">Protected Branches</h4>
+          <h4 className="font-semibold text-lg">Protected Branches</h4>
           <EditableList
             items={config.protectedBranches}
             reorderable
@@ -442,7 +442,7 @@ export const GlobalConfiguration: React.FC<GlobalConfigurationProps> = ({
 
         {/* Advanced Settings */}
         <div className="space-y-4">
-          <h4 className="font-black text-lg">Advanced Settings</h4>
+          <h4 className="font-semibold text-lg">Advanced Settings</h4>
            <div className="grid grid-cols-1 gap-4">
             <ConfigToggle
                id="autoMergeOnClean"
@@ -530,7 +530,7 @@ export const GlobalConfiguration: React.FC<GlobalConfigurationProps> = ({
 
         {/* Alert Configuration */}
         <div className="space-y-3">
-          <h4 className="font-black text-lg">Alert Configuration</h4>
+          <h4 className="font-semibold text-lg">Alert Configuration</h4>
           <div className="space-y-4">
             <ConfigSelector
               id="alertThreshold"
@@ -553,7 +553,7 @@ export const GlobalConfiguration: React.FC<GlobalConfigurationProps> = ({
 
         {/* System Configuration */}
         <div className="space-y-3">
-          <h4 className="font-black text-lg">System Configuration</h4>
+          <h4 className="font-semibold text-lg">System Configuration</h4>
           <div className="space-y-4">
             <ConfigSelector
               id="serverCheckInterval"

--- a/src/components/LogsTab.tsx
+++ b/src/components/LogsTab.tsx
@@ -64,7 +64,7 @@ export const LogsTab: React.FC<LogsTabProps> = ({ logs, onExportLogs, onClearLog
                 <FileText className="w-6 h-6" />
                 Activity Logs
               </CardTitle>
-              <CardDescription className="font-bold">
+              <CardDescription>
                 Track all system actions and events
               </CardDescription>
             </div>
@@ -120,14 +120,14 @@ export const LogsTab: React.FC<LogsTabProps> = ({ logs, onExportLogs, onClearLog
                     <Badge variant="secondary" className="nb-card text-white font-bold">
                       {log.category}
                     </Badge>
-                    <span className="text-sm text-muted-foreground font-bold">
+                    <span className="text-sm text-muted-foreground">
                       {log.timestamp.toLocaleString()}
                     </span>
                   </div>
-                  <p className="font-bold text-foreground">{log.message}</p>
+                  <p className="font-semibold text-foreground">{log.message}</p>
                   {log.details && (
                     <details className="mt-2">
-                      <summary className="cursor-pointer text-sm text-muted-foreground font-bold">
+                      <summary className="cursor-pointer text-sm text-muted-foreground">
                         View Details
                       </summary>
                       <pre className="mt-2 p-2 bg-muted rounded text-xs overflow-auto">
@@ -144,7 +144,7 @@ export const LogsTab: React.FC<LogsTabProps> = ({ logs, onExportLogs, onClearLog
         {filteredLogs.length === 0 && (
           <Card className="nb-card">
             <CardContent className="p-8 text-center">
-              <p className="text-muted-foreground font-bold">No logs match your filters</p>
+              <p className="text-muted-foreground">No logs match your filters</p>
             </CardContent>
           </Card>
         )}

--- a/src/components/RealtimeFeed.tsx
+++ b/src/components/RealtimeFeed.tsx
@@ -42,8 +42,8 @@ export const RealtimeFeed: React.FC<RealtimeFeedProps> = ({ activities, onExport
         <div className="absolute inset-0 bg-card/90 backdrop-blur-sm flex items-center justify-center z-10 rounded-lg">
           <div className="nb-card nb-red p-6">
             <div className="flex items-center gap-3">
-              <AlertTriangle className="w-6 h-6 text-white" />
-              <span className="font-black text-white text-lg">Authentication Required</span>
+              <AlertTriangle className="w-6 h-6" />
+              <span className="font-semibold text-white text-lg">Authentication Required</span>
             </div>
           </div>
         </div>
@@ -68,10 +68,10 @@ export const RealtimeFeed: React.FC<RealtimeFeedProps> = ({ activities, onExport
             {activities.length === 0 ? (
               <div className="text-center py-12">
                 <div className="nb-card nb-purple p-6 mx-auto w-fit mb-6">
-                  <Activity className="w-12 h-12 text-white mx-auto" />
+                  <Activity className="w-12 h-12 mx-auto opacity-50" />
                 </div>
-                <h3 className="font-black text-lg mb-2">No Recent Activity</h3>
-                <p className="text-muted-foreground font-bold">Enable repositories and API keys to see activity</p>
+                <h3 className="font-semibold text-lg mb-2">No Recent Activity</h3>
+                <p className="text-muted-foreground">Enable repositories and API keys to see activity</p>
               </div>
             ) : (
               activities.map((activity) => (
@@ -80,8 +80,8 @@ export const RealtimeFeed: React.FC<RealtimeFeedProps> = ({ activities, onExport
                     {getActivityIcon(activity.type)}
                   </div>
                   <div className="flex-1 min-w-0">
-                    <p className="font-black text-foreground truncate">{activity.message}</p>
-                    <p className="text-sm text-muted-foreground font-bold truncate">{activity.repo}</p>
+                    <p className="font-semibold text-foreground truncate">{activity.message}</p>
+                    <p className="text-sm text-muted-foreground truncate">{activity.repo}</p>
                   </div>
                   <div className="flex items-center gap-3 flex-shrink-0">
                     <Badge variant="outline" className="text-xs nb-card bg-card/50 font-bold">

--- a/src/components/RepositoryCard.tsx
+++ b/src/components/RepositoryCard.tsx
@@ -146,7 +146,7 @@ export const RepositoryCard: React.FC<RepositoryCardProps> = ({
           <div className="mt-4 p-3 rounded nb-card">
             <div className="flex items-center justify-between">
               <div>
-                <p className="font-bold text-sm">Latest Pull Request</p>
+                <p className="text-sm font-semibold">Latest Pull Request</p>
                 <p className="text-xs text-muted-foreground">
                   #{repo.recentPull.number} - {repo.recentPull.title}
                 </p>
@@ -208,20 +208,20 @@ export const RepositoryCard: React.FC<RepositoryCardProps> = ({
             {/* Repository Stats */}
             <div className="grid grid-cols-2 md:grid-cols-4 gap-2">
               <div className="nb-card p-3 nb-yellow text-center">
-                <p className="text-black font-black text-lg">{repo.stats.pendingMerges}</p>
-                <p className="text-black font-bold text-xs">Pending</p>
+                <p className="text-black font-semibold text-lg">{repo.stats.pendingMerges}</p>
+                <p className="text-black text-xs">Pending</p>
               </div>
               <div className="nb-card p-3 nb-green text-center">
-                <p className="text-black font-black text-lg">{repo.stats.successfulMerges}</p>
-                <p className="text-black font-bold text-xs">Success</p>
+                <p className="text-black font-semibold text-lg">{repo.stats.successfulMerges}</p>
+                <p className="text-black text-xs">Success</p>
               </div>
               <div className="nb-card p-3 nb-red text-center">
-                <p className="text-black font-black text-lg">{repo.stats.failedMerges}</p>
-                <p className="text-black font-bold text-xs">Failed</p>
+                <p className="text-black font-semibold text-lg">{repo.stats.failedMerges}</p>
+                <p className="text-black text-xs">Failed</p>
               </div>
               <div className="nb-card p-3 nb-purple text-center">
-                <p className="text-black font-black text-lg">{repo.stats.totalMerges}</p>
-                <p className="text-black font-bold text-xs">Total</p>
+                <p className="text-black font-semibold text-lg">{repo.stats.totalMerges}</p>
+                <p className="text-black text-xs">Total</p>
               </div>
             </div>
 

--- a/src/components/RepositoryManagement.tsx
+++ b/src/components/RepositoryManagement.tsx
@@ -193,7 +193,7 @@ export const RepositoryManagement: React.FC<RepositoryManagementProps> = ({
                   <div className="grid grid-cols-1 md:grid-cols-2 gap-6">
                     {/* Allowed Branches */}
                     <div>
-                      <h4 className="font-black text-lg mb-3 flex items-center gap-2">
+                      <h4 className="font-semibold text-lg mb-3 flex items-center gap-2">
                         <GitBranch className="w-5 h-5" />
                         Allowed Branch Patterns
                       </h4>
@@ -204,7 +204,7 @@ export const RepositoryManagement: React.FC<RepositoryManagementProps> = ({
                          placeholder="e.g., codex-feature/*"
                          itemColor="nb-yellow"
                        />
-                       <h4 className="font-black text-lg my-3 flex items-center gap-2">
+                       <h4 className="font-semibold text-lg my-3 flex items-center gap-2">
                          <GitBranch className="w-5 h-5" />
                          Protected Branches
                        </h4>
@@ -219,7 +219,7 @@ export const RepositoryManagement: React.FC<RepositoryManagementProps> = ({
 
                     {/* Allowed Users */}
                     <div>
-                      <h4 className="font-black text-lg mb-3 flex items-center gap-2">
+                      <h4 className="font-semibold text-lg mb-3 flex items-center gap-2">
                         <Users className="w-5 h-5" />
                         Allowed Users
                         {repo.allowAllUsers && (
@@ -242,7 +242,7 @@ export const RepositoryManagement: React.FC<RepositoryManagementProps> = ({
                   {/* Repository Configuration - Three Column Layout */}
                   <div className="grid grid-cols-1 md:grid-cols-3 gap-6">
                     <div>
-                      <h4 className="font-black text-lg mb-3 flex items-center gap-2">
+                      <h4 className="font-semibold text-lg mb-3 flex items-center gap-2">
                         <Key className="w-5 h-5" />
                         API Key
                       </h4>
@@ -260,7 +260,7 @@ export const RepositoryManagement: React.FC<RepositoryManagementProps> = ({
                     </div>
 
                     <div>
-                      <h4 className="font-black text-lg mb-3 flex items-center gap-2">
+                      <h4 className="font-semibold text-lg mb-3 flex items-center gap-2">
                         <GitBranch className="w-5 h-5" />
                         Fetch Mode
                       </h4>
@@ -277,7 +277,7 @@ export const RepositoryManagement: React.FC<RepositoryManagementProps> = ({
                     </div>
 
                   <div>
-                      <h4 className="font-black text-lg mb-3 flex items-center gap-2">
+                      <h4 className="font-semibold text-lg mb-3 flex items-center gap-2">
                         <Webhook className="w-5 h-5" />
                         Webhook Method
                       </h4>

--- a/src/components/SecurityManagement.tsx
+++ b/src/components/SecurityManagement.tsx
@@ -217,7 +217,7 @@ export const SecurityManagement: React.FC<SecurityManagementProps> = ({ apiKeys,
       <CardContent className="space-y-6">
         <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6">
           <div className="nb-card p-4 nb-purple">
-            <h4 className="font-black text-lg mb-2 text-black">Passkey Authentication</h4>
+            <h4 className="font-semibold text-lg mb-2 text-black">Passkey Authentication</h4>
             <p className="text-sm text-black font-bold mb-4">
               {passkeySupported ? 'Enable passkey authentication for enhanced security' : 'Passkeys not supported in this browser'}
             </p>
@@ -296,7 +296,7 @@ export const SecurityManagement: React.FC<SecurityManagementProps> = ({ apiKeys,
           </div>
           
           <div className="nb-card p-4 nb-orange">
-            <h4 className="font-black text-lg mb-2 text-black">Webhook Configuration</h4>
+            <h4 className="font-semibold text-lg mb-2 text-black">Webhook Configuration</h4>
             <p className="text-sm text-black font-bold mb-4">
               Configure webhooks for real-time notifications
             </p>
@@ -396,7 +396,7 @@ export const SecurityManagement: React.FC<SecurityManagementProps> = ({ apiKeys,
           </div>
 
           <div className="nb-card p-4 nb-green">
-            <h4 className="font-black text-lg mb-2 text-black">Encryption & Recovery</h4>
+            <h4 className="font-semibold text-lg mb-2 text-black">Encryption & Recovery</h4>
             <p className="text-sm text-black font-bold mb-4">
               Manage API key encryption and recovery options
             </p>
@@ -508,7 +508,7 @@ export const SecurityManagement: React.FC<SecurityManagementProps> = ({ apiKeys,
         </div>
         
         <div className="nb-card p-4 nb-pink">
-          <h4 className="font-black text-lg mb-2 text-black">Security Status</h4>
+          <h4 className="font-semibold text-lg mb-2 text-black">Security Status</h4>
           <div className="space-y-2">
             <div className="flex items-center gap-2">
               {apiKeysEncrypted ? (

--- a/src/components/ui/card.tsx
+++ b/src/components/ui/card.tsx
@@ -50,7 +50,7 @@ const CardDescription = React.forwardRef<
 >(({ className, ...props }, ref) => (
   <p
     ref={ref}
-    className={cn("text-sm text-muted-foreground font-bold", className)}
+    className={cn("text-sm text-muted-foreground", className)}
     {...props}
   />
 ))


### PR DESCRIPTION
## Summary
- reduce text weight for headings and muted text
- lighten empty state icons across components
- preserve muted color text

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_687a3503bfa08325998df1745dd04ab6