### PR TITLE
Persist dashboard theme selection

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,6 +76,10 @@ Read more here: [Setting up a custom domain](https://docs.lovable.dev/tips-trick
 
 The dashboard keeps a running history of actions in the **Logs** tab. You can download this history using **Export Logs** or remove it entirely using the new **Clear Logs** button next to the export option.
 
+## Theme preference
+
+The dashboard remembers whether you last used light or dark mode. This preference is stored locally so the interface loads with your chosen theme on your next visit.
+
 ## Server configuration
 
 The Node.js server polls GitHub for repository updates. The polling interval can

--- a/src/components/Dashboard.tsx
+++ b/src/components/Dashboard.tsx
@@ -72,7 +72,7 @@ export const Dashboard: React.FC = () => {
     fetchActivities
   } = useDashboardData();
 
-  const { appState, updateActiveTab } = useAppPersistence();
+  const { appState, updateActiveTab, updateTheme } = useAppPersistence();
   const { logInfo } = useLogger();
   const { theme, setTheme } = useTheme();
 
@@ -111,6 +111,7 @@ export const Dashboard: React.FC = () => {
   const toggleTheme = () => {
     const newTheme = theme === 'dark' ? 'light' : 'dark';
     setTheme(newTheme);
+    updateTheme(newTheme);
   };
 
   const tabs = [


### PR DESCRIPTION
## Summary
- save theme preference in `useAppPersistence`
- persist theme selection across sessions in the dashboard
- document theme persistence

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_687a45b3c6808325a883faadc46af7e6