### PR TITLE
Add socket server settings

### DIFF
--- a/src/components/GlobalConfiguration.tsx
+++ b/src/components/GlobalConfiguration.tsx
@@ -573,6 +573,33 @@ export const GlobalConfiguration: React.FC<GlobalConfigurationProps> = ({
               min={1}
               max={300}
             />
+            <div className="grid grid-cols-2 items-center gap-4">
+              <Label htmlFor="socketServerAddress" className="font-bold">Socket Server Address</Label>
+              <Input
+                id="socketServerAddress"
+                value={config.socketServerAddress}
+                onChange={(e) => onConfigChange({ ...config, socketServerAddress: e.target.value })}
+                className="neo-input"
+                placeholder="localhost"
+              />
+            </div>
+            <ConfigSelector
+              id="socketServerPort"
+              label="Socket Server Port"
+              value={config.socketServerPort}
+              onChange={(value) => onConfigChange({ ...config, socketServerPort: parseInt(value) })}
+              type="number"
+              min={1}
+              max={65535}
+            />
+            <ConfigSelector
+              id="socketMaxRetries"
+              label="Socket Max Retries"
+              value={config.socketMaxRetries}
+              onChange={(value) => onConfigChange({ ...config, socketMaxRetries: parseInt(value) })}
+              type="number"
+              min={0}
+            />
             <ConfigSelector
               id="logLevel"
               label="Log Level"

--- a/src/hooks/useGlobalConfig.ts
+++ b/src/hooks/useGlobalConfig.ts
@@ -23,6 +23,9 @@ const getDefaultConfig = (): GlobalConfig => ({
   fetchMode: 'github-api',
   serverCheckInterval: 30000, // 30 seconds
   refreshInterval: 30000,
+  socketServerAddress: 'localhost',
+  socketServerPort: 8080,
+  socketMaxRetries: 5,
   logLevel: 'info',
   darkMode: true,
   accentColor: '#313135',

--- a/src/types/dashboard.ts
+++ b/src/types/dashboard.ts
@@ -174,4 +174,10 @@ export interface GlobalConfig {
   /** Archive already closed PRs when fetching */
   autoArchiveClosed: boolean;
   refreshInterval: number;
+  /** Socket server hostname or IP */
+  socketServerAddress: string;
+  /** Socket server port */
+  socketServerPort: number;
+  /** Socket reconnection attempts */
+  socketMaxRetries: number;
 }


### PR DESCRIPTION
## Summary
- extend `GlobalConfig` interface with socket connection settings
- set default socket configuration in `useGlobalConfig`
- allow editing socket settings in `GlobalConfiguration`

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_687f7f4873d88325acfd2388d3c17cd6