### PR TITLE
Add configurable socket initialization

### DIFF
--- a/src/hooks/useGlobalConfig.ts
+++ b/src/hooks/useGlobalConfig.ts
@@ -101,6 +101,18 @@ export const useGlobalConfig = () => {
     getSocketService().setConfigSupplier(() => globalConfig);
   }, [globalConfig]);
 
+  useEffect(() => {
+    getSocketService().initialize(
+      globalConfig.socketServerAddress,
+      globalConfig.socketServerPort,
+      globalConfig.socketMaxRetries
+    );
+  }, [
+    globalConfig.socketServerAddress,
+    globalConfig.socketServerPort,
+    globalConfig.socketMaxRetries
+  ]);
+
   const resetConfig = () => {
     const defaultConfig = getDefaultConfig();
     setGlobalConfig(defaultConfig);


### PR DESCRIPTION
## Summary
- allow passing connection info into `SocketService.initialize`
- reconnect using the stored configuration
- initialize the socket with values from the global config

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_687f9cb287a08325b8e0deffa59d89d6