### PR TITLE
Implement server logs and improved theming

### DIFF
--- a/server/index.ts
+++ b/server/index.ts
@@ -16,6 +16,10 @@ export async function startServer(port: number = Number(process.env.PORT) || 300
     cors: { origin: '*' }
   });
 
+  app.get('/logs', (_req, res) => {
+    res.json({ logs: logger.getLogs() });
+  });
+
   registerSocketHandlers(io, app);
 
   httpServer.listen(port, () => {

--- a/server/logger.ts
+++ b/server/logger.ts
@@ -1,4 +1,19 @@
+type LogEntry = { id: string; timestamp: Date; level: 'info' | 'error'; message: string };
+const logs: LogEntry[] = [];
+
+function addLog(level: 'info' | 'error', args: unknown[]) {
+  const message = args.map(a => (typeof a === 'string' ? a : JSON.stringify(a))).join(' ');
+  logs.push({ id: Date.now().toString(36), timestamp: new Date(), level, message });
+}
+
 export const logger = {
-  info: (...args: unknown[]) => console.log('[info]', ...args),
-  error: (...args: unknown[]) => console.error('[error]', ...args)
+  info: (...args: unknown[]) => {
+    addLog('info', args);
+    console.log('[info]', ...args);
+  },
+  error: (...args: unknown[]) => {
+    addLog('error', args);
+    console.error('[error]', ...args);
+  },
+  getLogs: () => logs
 };

--- a/src/components/Dashboard.tsx
+++ b/src/components/Dashboard.tsx
@@ -67,6 +67,7 @@ export const Dashboard: React.FC = () => {
     // Other functions
     exportReport,
     exportLogs,
+    fetchServerLogs,
     clearLogs,
     addRepositoryActivity,
     fetchActivities
@@ -295,7 +296,7 @@ export const Dashboard: React.FC = () => {
           <TabsContent value="logs" className="space-y-6">
             <div className="max-w-4xl mx-auto">
               {!globalConfig.logsDisabled ? (
-                <LogsTab logs={logs} onExportLogs={exportLogs} onClearLogs={clearLogs} />
+                <LogsTab logs={logs} onExportLogs={exportLogs} onClearLogs={clearLogs} onFetchServerLogs={fetchServerLogs} />
               ) : (
                 <Card className="neo-card">
                   <CardContent className="flex flex-col items-center justify-center py-12">
@@ -313,21 +314,15 @@ export const Dashboard: React.FC = () => {
         </Tabs>
       </div>
 
-      {/* Quick Access Floating Button */}
-      <div className="fixed bottom-6 right-6 z-50">
-        <Button
-          onClick={() => {
-            const currentIndex = tabs.findIndex(tab => tab.key === appState.activeTab);
-            const nextTab = tabs[(currentIndex + 1) % tabs.length];
-            updateActiveTab(nextTab.key);
-            logInfo('dashboard', `Quick switched to ${nextTab.key} tab`);
-          }}
-          className="neo-button neo-blue rounded-full w-14 h-14 shadow-lg hover:shadow-xl"
-          size="icon"
-        >
-          <RefreshCw className="w-6 h-6" />
-        </Button>
-      </div>
+      {!isUnlocked && !authInProgress && (
+        <div className="fixed bottom-6 right-6 z-50">
+          <Button onClick={unlock} className="neo-button">
+            <Key className="w-4 h-4 mr-2" />
+            Authenticate
+          </Button>
+        </div>
+      )}
+
     </div>
   );
 };

--- a/src/components/LogsTab.tsx
+++ b/src/components/LogsTab.tsx
@@ -2,7 +2,7 @@ import React, { useState } from 'react';
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card';
 import { Button } from '@/components/ui/button';
 import { Badge } from '@/components/ui/badge';
-import { Download, FileText, Search, Filter, Trash2 } from 'lucide-react';
+import { Download, FileText, Search, Filter, Trash2, RefreshCw } from 'lucide-react';
 import { Input } from '@/components/ui/input';
 import { useToast } from '@/hooks/use-toast';
 
@@ -19,9 +19,10 @@ interface LogsTabProps {
   logs: LogEntry[];
   onExportLogs: () => void;
   onClearLogs: () => void;
+  onFetchServerLogs: () => void;
 }
 
-export const LogsTab: React.FC<LogsTabProps> = ({ logs, onExportLogs, onClearLogs }) => {
+export const LogsTab: React.FC<LogsTabProps> = ({ logs, onExportLogs, onClearLogs, onFetchServerLogs }) => {
   const [searchTerm, setSearchTerm] = useState('');
   const [levelFilter, setLevelFilter] = useState<string>('all');
   const { toast } = useToast();
@@ -77,6 +78,10 @@ export const LogsTab: React.FC<LogsTabProps> = ({ logs, onExportLogs, onClearLog
                 <Trash2 className="w-4 h-4 mr-2" />
 
                 Clear Logs
+              </Button>
+              <Button onClick={onFetchServerLogs} variant="outline" className="neo-button-secondary">
+                <RefreshCw className="w-4 h-4 mr-2" />
+                Sync Server
               </Button>
             </div>
           </div>

--- a/src/components/SelectiveRepositoryLoader.tsx
+++ b/src/components/SelectiveRepositoryLoader.tsx
@@ -89,6 +89,9 @@ export const SelectiveRepositoryLoader: React.FC<SelectiveRepositoryLoaderProps>
       }
       const service = createGitHubService(token);
       const repos = await service.fetchRepositories('');
+      if (!repos) {
+        throw new Error('no repositories');
+      }
       
       // Convert to our format and filter out already added repos
       const githubRepos: GitHubRepository[] = repos.map(repo => ({

--- a/src/components/ui/sonner.tsx
+++ b/src/components/ui/sonner.tsx
@@ -13,12 +13,12 @@ const Toaster = ({ ...props }: ToasterProps) => {
       toastOptions={{
         classNames: {
           toast:
-            "group toast group-[.toaster]:bg-background group-[.toaster]:text-foreground group-[.toaster]:border-border group-[.toaster]:shadow-lg",
+            "group neo-card group-[.toaster]:shadow-[4px_4px_0px_0px_hsl(var(--foreground)/0.5)]",
           description: "group-[.toast]:text-muted-foreground",
           actionButton:
-            "group-[.toast]:bg-primary group-[.toast]:text-primary-foreground",
+            "group-[.toast]:neo-button",
           cancelButton:
-            "group-[.toast]:bg-muted group-[.toast]:text-muted-foreground",
+            "group-[.toast]:neo-button-secondary",
         },
       }}
       {...props}

--- a/src/hooks/useDashboardData.ts
+++ b/src/hooks/useDashboardData.ts
@@ -11,7 +11,7 @@ export const useDashboardData = () => {
 
   const { clearWatchModeState } = useWatchModePersistence();
 
-  const { logs, exportLogs, clearLogs } = useLogger();
+  const { logs, exportLogs, clearLogs, fetchServerLogs } = useLogger();
 
 
   
@@ -160,6 +160,7 @@ export const useDashboardData = () => {
     updateStats,
     resetSessionStats,
     exportLogs,
+    fetchServerLogs,
     clearLogs,
     clearAllRepositories,
     clearAllApiKeys,

--- a/src/hooks/useLogger.ts
+++ b/src/hooks/useLogger.ts
@@ -134,6 +134,26 @@ export const useLogger = (
     setLogs([]);
   }, []);
 
+  const fetchServerLogs = useCallback(async () => {
+    try {
+      const res = await fetch('/logs');
+      if (!res.ok) return;
+      const data = await res.json();
+      if (Array.isArray(data.logs)) {
+        const serverEntries = data.logs.map((l: any) => ({
+          id: `srv-${l.id}`,
+          timestamp: new Date(l.timestamp),
+          level: l.level || 'info',
+          category: 'server',
+          message: l.message,
+        }));
+        setLogs(prev => [...serverEntries, ...prev]);
+      }
+    } catch (err) {
+      addLog('error', 'logger', 'Failed to fetch server logs', err);
+    }
+  }, [addLog]);
+
   const exportLogs = useCallback(() => {
     const logData = {
       exported: new Date().toISOString(),
@@ -163,7 +183,8 @@ export const useLogger = (
     logDebug,
     logSuccess,
     clearLogs,
-    exportLogs
+    exportLogs,
+    fetchServerLogs
   };
 };
 

--- a/src/index.css
+++ b/src/index.css
@@ -110,7 +110,7 @@
 
 @layer components {
   .neo-card {
-    @apply bg-card border-4 border-foreground shadow-[8px_8px_0px_0px_hsl(var(--foreground))];
+    @apply bg-card border-4 border-foreground shadow-[8px_8px_0px_0px_hsl(var(--foreground)/0.5)];
   }
   
   .neo-card.neo-yellow { @apply bg-[hsl(var(--neo-yellow))] text-black border-foreground; }
@@ -130,23 +130,23 @@
   .dark .neo-card.neo-red { @apply text-white border-2 border-gray-600; }
   
   .neo-button {
-    @apply bg-primary border-4 border-foreground shadow-[4px_4px_0px_0px_hsl(var(--foreground))]
-           hover:shadow-[2px_2px_0px_0px_hsl(var(--foreground))]
+    @apply bg-primary border-4 border-foreground shadow-[4px_4px_0px_0px_hsl(var(--foreground)/0.5)]
+           hover:shadow-[2px_2px_0px_0px_hsl(var(--foreground)/0.5)]
            hover:translate-x-[2px] hover:translate-y-[2px]
            transition-all duration-150 font-black uppercase tracking-wider;
   }
 
   
   .neo-button-secondary {
-    @apply bg-secondary border-4 border-foreground shadow-[4px_4px_0px_0px_hsl(var(--foreground))]
-           hover:shadow-[2px_2px_0px_0px_hsl(var(--foreground))]
+    @apply bg-secondary border-4 border-foreground shadow-[4px_4px_0px_0px_hsl(var(--foreground)/0.5)]
+           hover:shadow-[2px_2px_0px_0px_hsl(var(--foreground)/0.5)]
            hover:translate-x-[2px] hover:translate-y-[2px]
            transition-all duration-150 font-black uppercase tracking-wider;
   }
   
   .neo-input {
-    @apply bg-background border-4 border-foreground shadow-[4px_4px_0px_0px_hsl(var(--foreground))]
-           focus:shadow-[2px_2px_0px_0px_hsl(var(--foreground))]
+    @apply bg-background border-4 border-foreground shadow-[4px_4px_0px_0px_hsl(var(--foreground)/0.5)]
+           focus:shadow-[2px_2px_0px_0px_hsl(var(--foreground)/0.5)]
            focus:translate-x-[2px] focus:translate-y-[2px]
            transition-all duration-150 font-bold;
   }

--- a/src/services/BasicSocket.ts
+++ b/src/services/BasicSocket.ts
@@ -21,6 +21,15 @@ export class BasicSocket {
     return true;
   }
 
+  sendRequest(type: string, data: unknown, cb: MessageCallback): boolean {
+    if (!this.isConnected) return false;
+    setTimeout(() => {
+      this.emitMessage(type, data);
+      cb(undefined);
+    }, 10);
+    return true;
+  }
+
   onMessage(type: string, cb: MessageCallback): () => void {
     let set = this.listeners.get(type);
     if (!set) {

--- a/src/services/RealSocket.ts
+++ b/src/services/RealSocket.ts
@@ -1,0 +1,49 @@
+import { io, Socket } from 'socket.io-client';
+import type { MessageCallback } from './BasicSocket';
+
+export class RealSocket {
+  private socket: Socket;
+  isConnected = false;
+  latency = 0;
+
+  constructor(private url: string) {
+    this.socket = io(this.url, { autoConnect: false });
+  }
+
+  connect(): void {
+    this.socket.connect();
+    this.socket.on('connect', () => {
+      this.isConnected = true;
+    });
+    this.socket.on('disconnect', () => {
+      this.isConnected = false;
+    });
+    this.socket.on('pong', ms => {
+      this.latency = ms as number;
+    });
+  }
+
+  disconnect(): void {
+    this.socket.disconnect();
+    this.isConnected = false;
+  }
+
+  sendMessage(type: string, data: unknown): boolean {
+    if (!this.socket.connected) return false;
+    this.socket.emit(type, data);
+    return true;
+  }
+
+  sendRequest(type: string, data: unknown, cb: MessageCallback): boolean {
+    if (!this.socket.connected) return false;
+    this.socket.emit(type, data, cb);
+    return true;
+  }
+
+  onMessage(type: string, cb: MessageCallback): () => void {
+    this.socket.on(type, cb);
+    return () => {
+      this.socket.off(type, cb);
+    };
+  }
+}


### PR DESCRIPTION
## Summary
- tweak brutalist shadows
- restyle toast for brutalist look
- remove unused quick switch button
- show floating authentication prompt when locked
- allow client to use real socket connection
- expose server logs endpoint and fetch them in UI
- guard against undefined repos during load

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_687fa035ea448325b31f9b107b17ff3c