### PR TITLE
Fix server log sync on tab open

### DIFF
--- a/src/components/Dashboard.tsx
+++ b/src/components/Dashboard.tsx
@@ -103,11 +103,18 @@ export const Dashboard: React.FC = () => {
 
   // Log app initialization
   useEffect(() => {
-    logInfo('dashboard', 'Dashboard initialized', { 
+    logInfo('dashboard', 'Dashboard initialized', {
       sessionStart: appState.sessionStartTime,
       activeTab: appState.activeTab
     });
   }, []);
+
+  // Sync server logs whenever the Logs tab is opened
+  useEffect(() => {
+    if (appState.activeTab === 'logs') {
+      fetchServerLogs();
+    }
+  }, [appState.activeTab, fetchServerLogs]);
 
   const toggleTheme = () => {
     const newTheme = theme === 'dark' ? 'light' : 'dark';

--- a/src/hooks/useGlobalConfig.ts
+++ b/src/hooks/useGlobalConfig.ts
@@ -24,7 +24,7 @@ const getDefaultConfig = (): GlobalConfig => ({
   serverCheckInterval: 30000, // 30 seconds
   refreshInterval: 30000,
   socketServerAddress: 'localhost',
-  socketServerPort: 8080,
+  socketServerPort: 3001,
   socketMaxRetries: 5,
   logLevel: 'info',
   darkMode: true,

--- a/src/hooks/useLogger.ts
+++ b/src/hooks/useLogger.ts
@@ -1,4 +1,5 @@
 import { useState, useCallback, useEffect } from 'react';
+import { useGlobalConfig } from './useGlobalConfig';
 
 export interface LogEntry {
   id: string;
@@ -13,6 +14,7 @@ export const useLogger = (
   logLevel: 'info' | 'warn' | 'error' | 'debug' = 'info'
 ) => {
   const [logs, setLogs] = useState<LogEntry[]>([]);
+  const { globalConfig } = useGlobalConfig();
 
   const shouldLog = useCallback((level: LogEntry['level']): boolean => {
     const levels = ['debug', 'info', 'warn', 'error', 'success'];
@@ -88,7 +90,7 @@ export const useLogger = (
       console.warn = orig.warn;
       console.error = orig.error;
     };
-  }, [addLog]);
+  }, [addLog, globalConfig.socketServerAddress, globalConfig.socketServerPort]);
 
   useEffect(() => {
     addLog('info', 'system', 'Logger initialized');
@@ -136,7 +138,8 @@ export const useLogger = (
 
   const fetchServerLogs = useCallback(async () => {
     try {
-      const res = await fetch('/logs');
+      const url = `http://${globalConfig.socketServerAddress}:${globalConfig.socketServerPort}/logs`;
+      const res = await fetch(url);
       if (!res.ok) return;
       const data = await res.json();
       if (Array.isArray(data.logs)) {
@@ -152,7 +155,7 @@ export const useLogger = (
     } catch (err) {
       addLog('error', 'logger', 'Failed to fetch server logs', err);
     }
-  }, [addLog]);
+  }, [addLog, globalConfig.socketServerAddress, globalConfig.socketServerPort]);
 
   const exportLogs = useCallback(() => {
     const logData = {


### PR DESCRIPTION
## Summary
- default socket server port to 3001
- use server address and port when fetching logs
- auto-sync logs whenever the Logs tab is opened

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_687fa555e4e0832584b800c3ee83a66f