### PR TITLE
Add CORS middleware

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -42,6 +42,7 @@
         "class-variance-authority": "^0.7.1",
         "clsx": "^2.1.1",
         "cmdk": "^1.1.1",
+        "cors": "^2.8.5",
         "crypto-js": "^4.2.0",
         "date-fns": "^4.1.0",
         "embla-carousel-react": "^8.6.0",

--- a/package.json
+++ b/package.json
@@ -49,6 +49,7 @@
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",
     "cmdk": "^1.1.1",
+    "cors": "^2.8.5",
     "crypto-js": "^4.2.0",
     "date-fns": "^4.1.0",
     "embla-carousel-react": "^8.6.0",

--- a/server/index.ts
+++ b/server/index.ts
@@ -1,4 +1,5 @@
 import express from 'express';
+import cors from 'cors';
 import http from 'http';
 import { Server } from 'socket.io';
 import { registerSocketHandlers } from './socketHandlers.js';
@@ -9,6 +10,7 @@ import { fileURLToPath } from 'url';
 export async function startServer(port: number = Number(process.env.PORT) || 3001) {
   await loadPromise;
   const app = express();
+  app.use(cors());
   app.use(express.json());
 
   const httpServer = http.createServer(app);


### PR DESCRIPTION
## Summary
- allow Express endpoints to respond with CORS headers
- install `cors` library

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_687faff1f1a08325be17e839cd2c5f93