### PR TITLE
Implement passkey UI update and reset option

### DIFF
--- a/server/index.ts
+++ b/server/index.ts
@@ -10,7 +10,8 @@ import { fileURLToPath } from 'url';
 export async function startServer(port: number = Number(process.env.PORT) || 3001) {
   await loadPromise;
   const app = express();
-  app.use(cors());
+  app.use(cors({ origin: '*' }));
+  app.options('*', cors({ origin: '*' }));
   app.use(express.json());
 
   const httpServer = http.createServer(app);
@@ -19,6 +20,7 @@ export async function startServer(port: number = Number(process.env.PORT) || 300
   });
 
   app.get('/logs', (_req, res) => {
+    res.setHeader('Access-Control-Allow-Origin', '*');
     res.json({ logs: logger.getLogs() });
   });
 

--- a/server/logger.ts
+++ b/server/logger.ts
@@ -1,7 +1,7 @@
-type LogEntry = { id: string; timestamp: Date; level: 'info' | 'error'; message: string };
+type LogEntry = { id: string; timestamp: Date; level: 'info' | 'error' | 'warn'; message: string };
 const logs: LogEntry[] = [];
 
-function addLog(level: 'info' | 'error', args: unknown[]) {
+function addLog(level: 'info' | 'error' | 'warn', args: unknown[]) {
   const message = args.map(a => (typeof a === 'string' ? a : JSON.stringify(a))).join(' ');
   logs.push({ id: Date.now().toString(36), timestamp: new Date(), level, message });
 }
@@ -15,5 +15,28 @@ export const logger = {
     addLog('error', args);
     console.error('[error]', ...args);
   },
+  warn: (...args: unknown[]) => {
+    addLog('warn', args);
+    console.warn('[warn]', ...args);
+  },
   getLogs: () => logs
+};
+
+// Capture native console output so it also appears in the logs endpoint
+const origConsole = {
+  log: console.log,
+  warn: console.warn,
+  error: console.error
+};
+console.log = (...args: unknown[]) => {
+  addLog('info', args);
+  origConsole.log(...args);
+};
+console.warn = (...args: unknown[]) => {
+  addLog('warn', args);
+  origConsole.warn(...args);
+};
+console.error = (...args: unknown[]) => {
+  addLog('error', args);
+  origConsole.error(...args);
 };

--- a/src/components/Dashboard.tsx
+++ b/src/components/Dashboard.tsx
@@ -70,7 +70,8 @@ export const Dashboard: React.FC = () => {
     fetchServerLogs,
     clearLogs,
     addRepositoryActivity,
-    fetchActivities
+    fetchActivities,
+    purgeDatabase
   } = useDashboardData();
 
   const { appState, updateActiveTab, updateTheme } = useAppPersistence();
@@ -259,13 +260,14 @@ export const Dashboard: React.FC = () => {
 
           <TabsContent value="config" className="space-y-6">
             <div className="max-w-4xl mx-auto">
-              <GlobalConfiguration 
-                config={globalConfig} 
+              <GlobalConfiguration
+                config={globalConfig}
                 repositories={repositories}
                 apiKeys={apiKeys}
                 onConfigChange={setGlobalConfig}
                 onExportConfig={exportReport}
                 onImportConfig={() => logInfo('dashboard', 'Import config triggered')}
+                onPurgeDatabase={purgeDatabase}
               />
             </div>
           </TabsContent>
@@ -277,6 +279,7 @@ export const Dashboard: React.FC = () => {
                 repositories={repositories}
                 config={globalConfig}
                 onAuthenticate={unlock}
+                isUnlocked={isUnlocked}
               />
             </div>
           </TabsContent>

--- a/src/components/GlobalConfiguration.tsx
+++ b/src/components/GlobalConfiguration.tsx
@@ -28,6 +28,7 @@ interface GlobalConfigurationProps {
   onConfigChange: (config: GlobalConfig) => void;
   onExportConfig: () => void;
   onImportConfig: () => void;
+  onPurgeDatabase: () => void;
 }
 
 export const GlobalConfiguration: React.FC<GlobalConfigurationProps> = ({
@@ -36,7 +37,8 @@ export const GlobalConfiguration: React.FC<GlobalConfigurationProps> = ({
   apiKeys,
   onConfigChange,
   onExportConfig,
-  onImportConfig
+  onImportConfig,
+  onPurgeDatabase
 }) => {
   const [newPattern, setNewPattern] = useState('');
   const [newUser, setNewUser] = useState('');
@@ -52,6 +54,7 @@ export const GlobalConfiguration: React.FC<GlobalConfigurationProps> = ({
   const [exportPassword, setExportPassword] = useState('');
   const [importPassword, setImportPassword] = useState('');
   const [importFile, setImportFile] = useState<File | null>(null);
+  const [showResetDialog, setShowResetDialog] = useState(false);
   const { toast } = useToast();
   const { logInfo, logError, logWarn } = useLogger('info');
   const { clearWatchModeState } = useWatchModePersistence();
@@ -213,6 +216,7 @@ export const GlobalConfiguration: React.FC<GlobalConfigurationProps> = ({
   };
 
   return (
+    <>
     <Card className="neo-card">
       <CardHeader>
         <div className="flex items-center justify-between">
@@ -669,6 +673,14 @@ export const GlobalConfiguration: React.FC<GlobalConfigurationProps> = ({
                 <Trash2 className="w-4 h-4 mr-2" />
                 Clear Watch Mode
               </Button>
+              <Button
+                size="sm"
+                onClick={() => setShowResetDialog(true)}
+                className="neo-button bg-red-600 hover:bg-red-700 ml-2"
+              >
+                <RefreshCw className="w-4 h-4 mr-2" />
+                Reset to Defaults
+              </Button>
             </div>
           </div>
         </div>
@@ -683,5 +695,18 @@ export const GlobalConfiguration: React.FC<GlobalConfigurationProps> = ({
         />
       </CardContent>
     </Card>
+    <ConfirmationDialog
+      open={showResetDialog}
+      onOpenChange={setShowResetDialog}
+      title="Reset to Defaults?"
+      description="This will remove all stored data and restore default settings."
+      onConfirm={() => {
+        onPurgeDatabase();
+        toast({ title: 'Application reset to defaults' });
+      }}
+      confirmText="Reset"
+      variant="destructive"
+    />
+    </>
   );
 };

--- a/src/components/SecurityManagement.tsx
+++ b/src/components/SecurityManagement.tsx
@@ -19,9 +19,10 @@ interface SecurityManagementProps {
   repositories: Repository[];
   config: GlobalConfig;
   onAuthenticate: () => void;
+  isUnlocked: boolean;
 }
 
-export const SecurityManagement: React.FC<SecurityManagementProps> = ({ apiKeys, repositories, config, onAuthenticate }) => {
+export const SecurityManagement: React.FC<SecurityManagementProps> = ({ apiKeys, repositories, config, onAuthenticate, isUnlocked }) => {
   const [passkeySupported, setPasskeySupported] = useState(false);
   const [credentials, setCredentials] = useState<PasskeyCredential[]>([]);
   const [webhooks, setWebhooks] = useState<WebhookConfig[]>([]);
@@ -223,9 +224,13 @@ export const SecurityManagement: React.FC<SecurityManagementProps> = ({ apiKeys,
             </p>
             <div className="space-y-2">
               {credentials.length > 0 && (
-                <Button onClick={handleAuthenticatePasskey} className="neo-button bg-black text-white w-full">
+                <Button
+                  onClick={handleAuthenticatePasskey}
+                  disabled={isUnlocked}
+                  className={`neo-button bg-black text-white w-full ${isUnlocked ? 'opacity-50 cursor-default' : ''}`}
+                >
                   <Lock className="w-4 h-4 mr-2" />
-                  Authenticate
+                  {isUnlocked ? 'Authenticated' : 'Authenticate'}
                 </Button>
               )}
               <Dialog open={showPasskeyDialog} onOpenChange={setShowPasskeyDialog}>

--- a/src/hooks/useDashboardData.ts
+++ b/src/hooks/useDashboardData.ts
@@ -117,6 +117,15 @@ export const useDashboardData = () => {
     fetchActivities
   } = useActivities();
 
+  const purgeDatabase = () => {
+    resetConfig();
+    clearAllRepositories();
+    clearAllApiKeys();
+    clearWatchModeState();
+    resetSessionStats();
+    clearLogs();
+  };
+
   return {
     repositories,
     apiKeys,
@@ -165,6 +174,7 @@ export const useDashboardData = () => {
     clearAllRepositories,
     clearAllApiKeys,
     clearWatchModeState,
+    purgeDatabase,
     unlock,
     authInProgress,
     showLockedModal,


### PR DESCRIPTION
## Summary
- disable passkey auth button once unlocked
- capture console output on the server
- expose logs endpoint with proper CORS
- add reset to defaults option in config page
- plumb purge function through dashboard data

## Testing
- `npm test`
- `npm run build:server`


------
https://chatgpt.com/codex/tasks/task_e_687fb1f478748325894b7504f9fd3fd4