### PR TITLE
Fix persistence initialization

### DIFF
--- a/src/hooks/useAppPersistence.ts
+++ b/src/hooks/useAppPersistence.ts
@@ -28,6 +28,7 @@ export const useAppPersistence = () => {
       theme: 'light'
     },
   });
+  const [initialized, setInitialized] = useState(false);
 
   const { setTheme } = useTheme();
 
@@ -51,18 +52,21 @@ export const useAppPersistence = () => {
           console.error('Error parsing saved app state:', error);
         }
       }
+      setInitialized(true);
     })();
   }, []);
 
   useEffect(() => {
+    if (!initialized) return;
     setTheme(appState.userPreferences.theme);
-  }, [appState.userPreferences.theme, setTheme]);
+  }, [appState.userPreferences.theme, setTheme, initialized]);
 
   useEffect(() => {
+    if (!initialized) return;
     setItem(APP_STATE_STORAGE_KEY, appState).catch(err => {
       console.error('Error saving app state:', err);
     });
-  }, [appState]);
+  }, [appState, initialized]);
 
   const updateActiveTab = (tab: string) => {
     setAppState(prev => ({ 

--- a/src/hooks/useGlobalConfig.ts
+++ b/src/hooks/useGlobalConfig.ts
@@ -45,6 +45,7 @@ const getDefaultConfig = (): GlobalConfig => ({
 
 export const useGlobalConfig = () => {
   const [globalConfig, setGlobalConfig] = useState<GlobalConfig>(getDefaultConfig());
+  const [initialized, setInitialized] = useState(false);
   const { setTheme } = useTheme();
 
   useEffect(() => {
@@ -71,30 +72,34 @@ export const useGlobalConfig = () => {
           console.error('Error parsing saved config:', error);
         }
       }
+      setInitialized(true);
     })();
   }, []);
 
   // Persist config to IndexedDB whenever it changes
   useEffect(() => {
+    if (!initialized) return;
     setItem(GLOBAL_CONFIG_STORAGE_KEY, globalConfig).catch(err => {
       console.error('Error saving global config:', err);
     });
-  }, [globalConfig]);
+  }, [globalConfig, initialized]);
 
   // Update theme when darkMode or bwMode changes
   useEffect(() => {
+    if (!initialized) return;
     const theme = globalConfig.bwMode ? 'bw' : globalConfig.darkMode ? 'dark' : 'light';
     setItem('theme', theme);
     setTheme(theme);
-  }, [globalConfig.darkMode, globalConfig.bwMode, setTheme]);
+  }, [globalConfig.darkMode, globalConfig.bwMode, setTheme, initialized]);
 
   // Update accent color
   useEffect(() => {
+    if (!initialized) return;
     const hsl = hexToHSL(globalConfig.accentColor);
     document.documentElement.style.setProperty('--accent', hsl);
     document.documentElement.style.setProperty('--sidebar-accent', hsl);
     document.documentElement.style.setProperty('--primary', hsl);
-  }, [globalConfig.accentColor]);
+  }, [globalConfig.accentColor, initialized]);
 
   const updateConfig = (updates: Partial<GlobalConfig>) => {
     setGlobalConfig(prev => ({ ...prev, ...updates }));

--- a/src/hooks/useStatsPersistence.ts
+++ b/src/hooks/useStatsPersistence.ts
@@ -9,6 +9,7 @@ export const useStatsPersistence = () => {
     session: { pending: 0, merged: 0, failed: 0 },
     total: { pending: 0, merged: 0, failed: 0 }
   });
+  const [initialized, setInitialized] = useState(false);
 
   useEffect(() => {
     (async () => {
@@ -21,15 +22,17 @@ export const useStatsPersistence = () => {
           console.error('Error parsing saved stats:', error);
         }
       }
+      setInitialized(true);
     })();
   }, []);
 
 
   useEffect(() => {
+    if (!initialized) return;
     setItem(STATS_STORAGE_KEY, mergeStats).catch(err => {
       console.error('Error saving stats:', err);
     });
-  }, [mergeStats]);
+  }, [mergeStats, initialized]);
 
   const updateStats = (newStats: Partial<MergeStats>) => {
     setMergeStats(prev => ({

--- a/src/hooks/useWatchModePersistence.ts
+++ b/src/hooks/useWatchModePersistence.ts
@@ -36,6 +36,7 @@ export const useWatchModePersistence = () => {
     repoStrayBranches: {},
     repoLastFetched: {}
   });
+  const [initialized, setInitialized] = useState(false);
 
   useEffect(() => {
     (async () => {
@@ -62,6 +63,7 @@ export const useWatchModePersistence = () => {
           console.error('Error parsing saved watch mode state:', error);
         }
       }
+      setInitialized(true);
     })();
   }, []);
 
@@ -80,10 +82,11 @@ export const useWatchModePersistence = () => {
   // No storage events for IndexedDB; state is local to the tab
 
   useEffect(() => {
+    if (!initialized) return;
     setItem(WATCH_MODE_STORAGE_KEY, watchModeState).catch(err => {
       console.error('Error saving watch mode state:', err);
     });
-  }, [watchModeState]);
+  }, [watchModeState, initialized]);
 
   const updateRepoActivities = (repoId: string, activities: ActivityItem[]) => {
     const trimmed = activities.slice(-MAX_ITEMS);


### PR DESCRIPTION
## Summary
- delay persistence effects until storage finishes loading
- ensure theme and accent color apply only after initialization
- avoid overwriting previously saved data

## Testing
- `npm run build`
- `npm test --silent`
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_687ff12bcd6c8325bcd3df41323f5f6f