### PR TITLE
Improve brutalist styling and config sync

### DIFF
--- a/src/components/SecurityManagement.tsx
+++ b/src/components/SecurityManagement.tsx
@@ -491,7 +491,7 @@ export const SecurityManagement: React.FC<SecurityManagementProps> = ({ apiKeys,
                           </p>
                           <div className="p-4 bg-muted rounded max-w-full">
                             {showRecoveryPhrase ? (
-                              <div className="font-mono text-sm break-words whitespace-pre-wrap max-h-32 overflow-y-auto">
+                              <div className="font-mono text-sm break-words whitespace-pre-wrap max-h-32 overflow-y-auto overflow-x-auto">
                                 {recoveryPhrase}
                               </div>
                             ) : (

--- a/src/components/SelectiveRepositoryLoader.tsx
+++ b/src/components/SelectiveRepositoryLoader.tsx
@@ -223,7 +223,7 @@ export const SelectiveRepositoryLoader: React.FC<SelectiveRepositoryLoaderProps>
         <div className="flex gap-4 items-center">
           <div className="flex-1">
             <Select value={selectedApiKey} onValueChange={setSelectedApiKey}>
-              <SelectTrigger>
+              <SelectTrigger className="neo-input">
                 <SelectValue placeholder="Select an API key" />
               </SelectTrigger>
               <SelectContent>
@@ -276,7 +276,7 @@ export const SelectiveRepositoryLoader: React.FC<SelectiveRepositoryLoaderProps>
                 </div>
               </div>
               <Select value={filterType} onValueChange={(value: 'all' | 'public' | 'private') => setFilterType(value)}>
-                <SelectTrigger className="w-32">
+                <SelectTrigger className="w-32 neo-input">
                   <SelectValue />
                 </SelectTrigger>
                 <SelectContent>
@@ -286,7 +286,7 @@ export const SelectiveRepositoryLoader: React.FC<SelectiveRepositoryLoaderProps>
                 </SelectContent>
               </Select>
               <Select value={sortBy} onValueChange={(value: 'name' | 'updated' | 'stars') => setSortBy(value)}>
-                <SelectTrigger className="w-32">
+                <SelectTrigger className="w-32 neo-input">
                   <SelectValue />
                 </SelectTrigger>
                 <SelectContent>

--- a/src/components/ui/toast.tsx
+++ b/src/components/ui/toast.tsx
@@ -23,13 +23,12 @@ const ToastViewport = React.forwardRef<
 ToastViewport.displayName = ToastPrimitives.Viewport.displayName
 
 const toastVariants = cva(
-  "group pointer-events-auto relative flex w-full items-center justify-between space-x-4 overflow-hidden rounded-md border p-6 pr-8 shadow-lg transition-all data-[swipe=cancel]:translate-x-0 data-[swipe=end]:translate-x-[var(--radix-toast-swipe-end-x)] data-[swipe=move]:translate-x-[var(--radix-toast-swipe-move-x)] data-[swipe=move]:transition-none data-[state=open]:animate-in data-[state=closed]:animate-out data-[swipe=end]:animate-out data-[state=closed]:fade-out-80 data-[state=closed]:slide-out-to-right-full data-[state=open]:slide-in-from-top-full data-[state=open]:sm:slide-in-from-bottom-full",
+  "group pointer-events-auto relative flex w-full items-center justify-between space-x-4 overflow-hidden neo-toast p-6 pr-8 transition-all data-[swipe=cancel]:translate-x-0 data-[swipe=end]:translate-x-[var(--radix-toast-swipe-end-x)] data-[swipe=move]:translate-x-[var(--radix-toast-swipe-move-x)] data-[swipe=move]:transition-none data-[state=open]:animate-in data-[state=closed]:animate-out data-[swipe=end]:animate-out data-[state=closed]:fade-out-80 data-[state=closed]:slide-out-to-right-full data-[state=open]:slide-in-from-top-full data-[state=open]:sm:slide-in-from-bottom-full",
   {
     variants: {
       variant: {
-        default: "border bg-background text-foreground",
-        destructive:
-          "destructive group border-destructive bg-destructive text-destructive-foreground",
+        default: "neo-toast",
+        destructive: "neo-toast neo-red",
       },
     },
     defaultVariants: {
@@ -59,10 +58,7 @@ const ToastAction = React.forwardRef<
 >(({ className, ...props }, ref) => (
   <ToastPrimitives.Action
     ref={ref}
-    className={cn(
-      "inline-flex h-8 shrink-0 items-center justify-center rounded-md border bg-transparent px-3 text-sm font-medium ring-offset-background transition-colors hover:bg-secondary focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2 disabled:pointer-events-none disabled:opacity-50 group-[.destructive]:border-muted/40 group-[.destructive]:hover:border-destructive/30 group-[.destructive]:hover:bg-destructive group-[.destructive]:hover:text-destructive-foreground group-[.destructive]:focus:ring-destructive",
-      className
-    )}
+    className={cn("neo-button", className)}
     {...props}
   />
 ))
@@ -75,7 +71,7 @@ const ToastClose = React.forwardRef<
   <ToastPrimitives.Close
     ref={ref}
     className={cn(
-      "absolute right-2 top-2 rounded-md p-1 text-foreground/50 opacity-0 transition-opacity hover:text-foreground focus:opacity-100 focus:outline-none focus:ring-2 group-hover:opacity-100 group-[.destructive]:text-red-300 group-[.destructive]:hover:text-red-50 group-[.destructive]:focus:ring-red-400 group-[.destructive]:focus:ring-offset-red-600",
+      "absolute right-2 top-2 neo-button-secondary p-1 opacity-0 transition-opacity group-hover:opacity-100",
       className
     )}
     toast-close=""

--- a/src/hooks/useGlobalConfig.ts
+++ b/src/hooks/useGlobalConfig.ts
@@ -110,6 +110,11 @@ export const useGlobalConfig = () => {
   }, [globalConfig]);
 
   useEffect(() => {
+    if (!initialized) return;
+    getSocketService().syncConfigWithServer();
+  }, [globalConfig, initialized]);
+
+  useEffect(() => {
     getSocketService().initialize(
       globalConfig.socketServerAddress,
       globalConfig.socketServerPort,

--- a/src/index.css
+++ b/src/index.css
@@ -197,6 +197,19 @@
            focus:translate-x-[2px] focus:translate-y-[2px]
            transition-all duration-150 font-bold;
   }
+
+  .neo-switch {
+    @apply border-4 border-foreground shadow-[2px_2px_0px_0px_hsl(var(--foreground)/0.5)]
+           data-[state=checked]:bg-primary data-[state=unchecked]:bg-input;
+  }
+
+  .neo-switch-thumb {
+    @apply bg-background border-2 border-foreground shadow;
+  }
+
+  .neo-toast {
+    @apply neo-card;
+  }
   
 }
 

--- a/src/services/SocketService.ts
+++ b/src/services/SocketService.ts
@@ -123,6 +123,10 @@ export class SocketService {
     this.configSupplier = fn;
   }
 
+  syncConfigWithServer() {
+    this.syncConfig();
+  }
+
   private syncConfig(): void {
     if (!this.socket?.isConnected || !this.pairedClients.has(this.clientId)) return;
     const cfg = this.configSupplier ? this.configSupplier() : null;


### PR DESCRIPTION
## Summary
- update toast component to use brutalist styles
- tweak brutalsim utilities for switch and toast
- apply brutalist look to repo loader dropdowns
- prevent overflow in recovery phrase display
- sync config with server when it changes

## Testing
- `npm run lint`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_688002aeb8b48325b4cbe20d4a7ef218