### PR TITLE
Add debugging logs and fix duplicate server log IDs

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "version": "0.0.0",
   "type": "module",
   "scripts": {
-    "dev": "npm run build:server && concurrently \"vite\" \"node server/dist/index.js\"",
+    "dev": "npm run build:server && concurrently --raw \"vite\" \"node server/dist/index.js\"",
     "build": "vite build && npm run build:server",
     "build:dev": "vite build --mode development && npm run build:server",
     "lint": "eslint .",

--- a/server/logger.ts
+++ b/server/logger.ts
@@ -8,7 +8,8 @@ const logs: LogEntry[] = [];
 
 function addLog(level: LogEntry['level'], args: unknown[]) {
   const message = args.map(a => (typeof a === 'string' ? a : JSON.stringify(a))).join(' ');
-  logs.push({ id: Date.now().toString(36), timestamp: new Date(), level, message });
+  const id = Date.now().toString(36) + Math.random().toString(36).slice(2, 8);
+  logs.push({ id, timestamp: new Date(), level, message });
 }
 
 export const logger = {

--- a/server/logger.ts
+++ b/server/logger.ts
@@ -1,7 +1,12 @@
-type LogEntry = { id: string; timestamp: Date; level: 'info' | 'error' | 'warn'; message: string };
+type LogEntry = {
+  id: string;
+  timestamp: Date;
+  level: 'info' | 'error' | 'warn' | 'debug';
+  message: string;
+};
 const logs: LogEntry[] = [];
 
-function addLog(level: 'info' | 'error' | 'warn', args: unknown[]) {
+function addLog(level: LogEntry['level'], args: unknown[]) {
   const message = args.map(a => (typeof a === 'string' ? a : JSON.stringify(a))).join(' ');
   logs.push({ id: Date.now().toString(36), timestamp: new Date(), level, message });
 }
@@ -19,6 +24,10 @@ export const logger = {
     addLog('warn', args);
     console.warn('[warn]', ...args);
   },
+  debug: (...args: unknown[]) => {
+    addLog('debug', args);
+    console.debug('[debug]', ...args);
+  },
   getLogs: () => logs
 };
 
@@ -26,7 +35,8 @@ export const logger = {
 const origConsole = {
   log: console.log,
   warn: console.warn,
-  error: console.error
+  error: console.error,
+  debug: console.debug
 };
 console.log = (...args: unknown[]) => {
   addLog('info', args);
@@ -39,4 +49,8 @@ console.warn = (...args: unknown[]) => {
 console.error = (...args: unknown[]) => {
   addLog('error', args);
   origConsole.error(...args);
+};
+console.debug = (...args: unknown[]) => {
+  addLog('debug', args);
+  origConsole.debug(...args);
 };

--- a/server/socketHandlers.ts
+++ b/server/socketHandlers.ts
@@ -77,6 +77,7 @@ app.post('/pairings/:token/deny', (req, res) => {
 });
 
 io.on('connection', (socket: Socket) => {
+  logger.debug('socket', 'client connected', { id: socket.id });
   const s = socket as ExtendedSocket;
   s.subscriptions = new Set();
   s.isPaired = false;
@@ -89,6 +90,7 @@ io.on('connection', (socket: Socket) => {
   });
 
   socket.on('pair_request', ({ clientId }) => {
+    logger.debug('socket', 'pair_request received', { clientId });
     cleanupPairings();
     const entry = pendingPairings.get(s.pairToken);
     if (!entry) return;
@@ -98,6 +100,7 @@ io.on('connection', (socket: Socket) => {
   });
 
   socket.on('syncConfig', async (config, cb = () => {}) => {
+    logger.debug('socket', 'syncConfig received', { clientId: s.clientId });
     if (!requirePaired(s, cb)) return;
     try {
       await setClientConfig(s.clientId, config || {});
@@ -107,6 +110,7 @@ io.on('connection', (socket: Socket) => {
     }
   });
   socket.on('fetchRepos', async (params, cb = () => {}) => {
+    logger.debug('socket', 'fetchRepos received', { clientId: s.clientId });
     if (!requirePaired(s, cb)) return;
     try {
       const svc = createGitHubService(params.token);
@@ -118,6 +122,7 @@ io.on('connection', (socket: Socket) => {
   });
 
   socket.on('fetchPullRequests', async (params, cb = () => {}) => {
+    logger.debug('socket', 'fetchPullRequests received', { clientId: s.clientId });
     if (!requirePaired(s, cb)) return;
     try {
       const svc = createGitHubService(params.token);
@@ -134,6 +139,7 @@ io.on('connection', (socket: Socket) => {
   });
 
   socket.on('mergePR', async (params, cb = () => {}) => {
+    logger.debug('socket', 'mergePR received', { clientId: s.clientId });
     if (!requirePaired(s, cb)) return;
     try {
       const svc = createGitHubService(params.token);
@@ -145,6 +151,7 @@ io.on('connection', (socket: Socket) => {
   });
 
   socket.on('closePR', async (params, cb = () => {}) => {
+    logger.debug('socket', 'closePR received', { clientId: s.clientId });
     if (!requirePaired(s, cb)) return;
     try {
       const svc = createGitHubService(params.token);
@@ -156,6 +163,7 @@ io.on('connection', (socket: Socket) => {
   });
 
   socket.on('deleteBranch', async (params, cb = () => {}) => {
+    logger.debug('socket', 'deleteBranch received', { clientId: s.clientId });
     if (!requirePaired(s, cb)) return;
     const {
       token,
@@ -194,6 +202,7 @@ io.on('connection', (socket: Socket) => {
   });
 
   socket.on('fetchStrayBranches', async (params, cb = () => {}) => {
+    logger.debug('socket', 'fetchStrayBranches received', { clientId: s.clientId });
     if (!requirePaired(s, cb)) return;
     try {
       const svc = createGitHubService(params.token);
@@ -220,6 +229,7 @@ io.on('connection', (socket: Socket) => {
   });
 
   socket.on('fetchRecentActivity', async (params, cb = () => {}) => {
+    logger.debug('socket', 'fetchRecentActivity received', { clientId: s.clientId });
     if (!requirePaired(s, cb)) return;
     try {
       const svc = createGitHubService(params.token);
@@ -241,18 +251,21 @@ io.on('connection', (socket: Socket) => {
   });
 
   socket.on('subscribeRepo', params => {
+    logger.debug('socket', 'subscribeRepo received', { clientId: s.clientId });
     if (!requirePaired(s)) return;
     subscribeRepo(s, params);
     s.subscriptions.add(`${params.owner}/${params.repo}`);
   });
 
   socket.on('unsubscribeRepo', params => {
+    logger.debug('socket', 'unsubscribeRepo received', { clientId: s.clientId });
     if (!requirePaired(s)) return;
     unsubscribeRepo(s, params);
     s.subscriptions.delete(`${params.owner}/${params.repo}`);
   });
 
   socket.on('checkPRMergeable', async (params, cb = () => {}) => {
+    logger.debug('socket', 'checkPRMergeable received', { clientId: s.clientId });
     if (!requirePaired(s, cb)) return;
     try {
       const svc = createGitHubService(params.token);
@@ -264,6 +277,7 @@ io.on('connection', (socket: Socket) => {
   });
 
   socket.on('disconnect', () => {
+    logger.debug('socket', 'client disconnected', { id: socket.id, clientId: s.clientId });
     for (const key of s.subscriptions) {
       const [owner, repo] = key.split('/');
       unsubscribeRepo(s, { owner, repo });

--- a/src/hooks/useLogger.ts
+++ b/src/hooks/useLogger.ts
@@ -150,9 +150,15 @@ export const useLogger = (
           category: 'server',
           message: l.message,
         }));
+        const seen = new Set<string>();
+        const deduped = serverEntries.filter(e => {
+          if (seen.has(e.id)) return false;
+          seen.add(e.id);
+          return true;
+        });
         setLogs(prev => {
           const existingIds = new Set(prev.map(e => e.id));
-          const unique = serverEntries.filter(e => !existingIds.has(e.id));
+          const unique = deduped.filter(e => !existingIds.has(e.id));
           return [...unique, ...prev];
         });
       }

--- a/src/hooks/useLogger.ts
+++ b/src/hooks/useLogger.ts
@@ -146,11 +146,15 @@ export const useLogger = (
         const serverEntries = data.logs.map((l: any) => ({
           id: `srv-${l.id}`,
           timestamp: new Date(l.timestamp),
-          level: l.level || 'info',
+          level: (l.level || 'info') as LogEntry['level'],
           category: 'server',
           message: l.message,
         }));
-        setLogs(prev => [...serverEntries, ...prev]);
+        setLogs(prev => {
+          const existingIds = new Set(prev.map(e => e.id));
+          const unique = serverEntries.filter(e => !existingIds.has(e.id));
+          return [...unique, ...prev];
+        });
       }
     } catch (err) {
       addLog('error', 'logger', 'Failed to fetch server logs', err);


### PR DESCRIPTION
## Summary
- log debug messages on the socket server
- capture `console.debug` output in server logs
- avoid duplicating server log entries in the client logger

## Testing
- `npm test`
- `npm run build:server`
- `npm run lint`
- `npm run dev` *(fails: write EPIPE during vite scan but server started)*

------
https://chatgpt.com/codex/tasks/task_e_6880106561d083259070c16d3a99190b