### PR TITLE
Add socket ping latency display

### DIFF
--- a/server/socketHandlers.ts
+++ b/server/socketHandlers.ts
@@ -263,6 +263,10 @@ io.on('connection', (socket: Socket) => {
     }
   });
 
+  socket.on('ping', data => {
+    socket.emit('pong', data);
+  });
+
   socket.on('disconnect', () => {
     for (const key of s.subscriptions) {
       const [owner, repo] = key.split('/');

--- a/src/components/ConnectionManager.tsx
+++ b/src/components/ConnectionManager.tsx
@@ -3,6 +3,7 @@ import { Badge } from '@/components/ui/badge';
 import { Button } from '@/components/ui/button';
 import { Wifi, WifiOff, RefreshCw, Github, Server, Key } from 'lucide-react';
 import { useLogger } from '@/hooks/useLogger';
+import { getSocketService } from '@/services/SocketService';
 
 import { ApiKey } from '@/types/dashboard';
 
@@ -25,13 +26,13 @@ export const ConnectionManager: React.FC<ConnectionManagerProps> = ({ apiKeys, c
 
   const handleRefresh = useCallback(async () => {
     setIsRefreshing(true);
-    
+
     try {
-      // In this demo we simply mark the services as connected when an API key exists
+      const svc = getSocketService();
       setGithubConnected(activeApiKeys > 0);
       setPublicApiConnected(activeApiKeys > 0);
-      setSocketConnected(activeApiKeys > 0);
-      setLatency(0);
+      setSocketConnected(svc.isConnected);
+      setLatency(svc.latency);
     } catch (error) {
       console.error('Connection check failed:', error);
       setGithubConnected(false);
@@ -53,6 +54,16 @@ export const ConnectionManager: React.FC<ConnectionManagerProps> = ({ apiKeys, c
     
     return () => clearInterval(interval);
   }, [checkInterval, activeApiKeys, handleRefresh]);
+
+  // update latency regularly
+  useEffect(() => {
+    const svc = getSocketService();
+    const interval = setInterval(() => {
+      setSocketConnected(svc.isConnected);
+      setLatency(svc.latency);
+    }, 1000);
+    return () => clearInterval(interval);
+  }, []);
 
   if (compact) {
     return (

--- a/src/services/BasicSocket.ts
+++ b/src/services/BasicSocket.ts
@@ -17,6 +17,14 @@ export class BasicSocket {
 
   sendMessage(type: string, data: unknown): boolean {
     if (!this.isConnected) return false;
+    if (type === 'ping') {
+      const delay = Math.floor(Math.random() * 50) + 10;
+      setTimeout(() => {
+        this.latency = Date.now() - (data as any).timestamp;
+        this.emitMessage('pong', data);
+      }, delay);
+      return true;
+    }
     setTimeout(() => this.emitMessage(type, data), 0);
     return true;
   }

--- a/src/services/RealSocket.ts
+++ b/src/services/RealSocket.ts
@@ -18,9 +18,6 @@ export class RealSocket {
     this.socket.on('disconnect', () => {
       this.isConnected = false;
     });
-    this.socket.on('pong', ms => {
-      this.latency = ms as number;
-    });
   }
 
   disconnect(): void {


### PR DESCRIPTION
## Summary
- respond to `ping` events with `pong` on the server
- simulate ping handling in `BasicSocket`
- track latency in `SocketService` by regularly sending `ping`
- remove old latency code in `RealSocket`
- show the measured latency in `ConnectionManager`

## Testing
- `npm test`
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_688014aa65b88325a540c547cd053752