### PR TITLE
Add ping and socket service tests

### DIFF
--- a/server/__tests__/socketHandlers.test.ts
+++ b/server/__tests__/socketHandlers.test.ts
@@ -135,4 +135,13 @@ describe('socket handlers', () => {
     });
     expect(resp).toEqual({ ok: true, data: ['remove'] });
   });
+
+  it('responds to ping with pong', async () => {
+    const payload = { hello: 'world' };
+    const resp = await new Promise(resolve => {
+      client.once('pong', resolve);
+      client.emit('ping', payload);
+    });
+    expect(resp).toEqual(payload);
+  });
 });

--- a/src/__tests__/SocketService.test.ts
+++ b/src/__tests__/SocketService.test.ts
@@ -1,0 +1,50 @@
+import { describe, it, beforeEach, afterEach, expect, vi } from 'vitest';
+
+beforeEach(() => {
+  vi.resetModules();
+});
+
+afterEach(() => {
+  vi.clearAllMocks();
+  vi.unmock('../services/BasicSocket.ts');
+});
+
+describe('SocketService initialization', () => {
+  it('uses configuration values when connecting', async () => {
+    const { SocketService } = await import('../services/SocketService.ts');
+    const { logger } = await import('../services/Logger');
+    const infoSpy = vi.spyOn(logger, 'logInfo').mockImplementation(() => {});
+    const svc = new SocketService();
+    const ok = svc.initialize('example.com', 1234, 1);
+    expect(ok).toBe(true);
+    expect(infoSpy).toHaveBeenCalledWith(
+      'socket',
+      'Socket service initialized',
+      expect.objectContaining({ url: 'http://example.com:1234' })
+    );
+    svc.disconnect();
+  });
+
+  it('respects retry limit on failed connections', async () => {
+    const connectMock = vi.fn();
+    vi.doMock('../services/BasicSocket.ts', () => {
+      return {
+        BasicSocket: vi.fn().mockImplementation(() => ({
+          isConnected: false,
+          latency: 0,
+          connect: connectMock,
+          disconnect: vi.fn(),
+          sendMessage: vi.fn(),
+          sendRequest: vi.fn(),
+          onMessage: vi.fn()
+        }))
+      };
+    });
+    const { SocketService } = await import('../services/SocketService.ts');
+    const { logger } = await import('../services/Logger');
+    const svc = new SocketService();
+    const ok = svc.initialize('host', 1111, 2);
+    expect(ok).toBe(false);
+    expect(connectMock).toHaveBeenCalledTimes(3);
+  });
+});


### PR DESCRIPTION
## Summary
- check new `ping` handler in the server
- cover `SocketService` initialization logic and retry limit

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6880947bfdac8325b7cd7854c8d4d401