### PR TITLE
Add lock functionality for API keys

### DIFF
--- a/src/components/Dashboard.tsx
+++ b/src/components/Dashboard.tsx
@@ -62,6 +62,7 @@ export const Dashboard: React.FC = () => {
     setGlobalConfig,
     // Auth functions
     unlock,
+    lock,
     // Other functions
     exportReport,
     exportLogs,
@@ -272,6 +273,7 @@ export const Dashboard: React.FC = () => {
                 repositories={repositories}
                 config={globalConfig}
                 onAuthenticate={unlock}
+                onLock={lock}
                 isUnlocked={isUnlocked}
               />
             </div>

--- a/src/components/SecurityManagement.tsx
+++ b/src/components/SecurityManagement.tsx
@@ -19,10 +19,11 @@ interface SecurityManagementProps {
   repositories: Repository[];
   config: GlobalConfig;
   onAuthenticate: () => void;
+  onLock: () => void;
   isUnlocked: boolean;
 }
 
-export const SecurityManagement: React.FC<SecurityManagementProps> = ({ apiKeys, repositories, config, onAuthenticate, isUnlocked }) => {
+export const SecurityManagement: React.FC<SecurityManagementProps> = ({ apiKeys, repositories, config, onAuthenticate, onLock, isUnlocked }) => {
   const [passkeySupported, setPasskeySupported] = useState(false);
   const [credentials, setCredentials] = useState<PasskeyCredential[]>([]);
   const [webhooks, setWebhooks] = useState<WebhookConfig[]>([]);
@@ -231,6 +232,12 @@ export const SecurityManagement: React.FC<SecurityManagementProps> = ({ apiKeys,
                 >
                   <Lock className="w-4 h-4 mr-2" />
                   {isUnlocked ? 'Authenticated' : 'Authenticate'}
+                </Button>
+              )}
+              {credentials.length > 0 && isUnlocked && (
+                <Button onClick={onLock} className="neo-button bg-black text-white w-full">
+                  <Lock className="w-4 h-4 mr-2" />
+                  Lock Keys
                 </Button>
               )}
               <Dialog open={showPasskeyDialog} onOpenChange={setShowPasskeyDialog}>

--- a/src/hooks/useApiKeys.ts
+++ b/src/hooks/useApiKeys.ts
@@ -128,6 +128,14 @@ export const useApiKeys = () => {
     }
   };
 
+  const lock = () => {
+    setDecryptedKeys({});
+    setUnlocked(false);
+    if (typeof (PasskeyService as any).resetAuth === 'function') {
+      (PasskeyService as any).resetAuth();
+    }
+  };
+
   useEffect(() => {
     unlock();
     // intentionally run once on mount
@@ -337,6 +345,7 @@ export const useApiKeys = () => {
     refreshApiKeyStatus,
     clearAllApiKeys,
     unlock,
+    lock,
     authInProgress
   };
 };

--- a/src/hooks/useDashboardData.ts
+++ b/src/hooks/useDashboardData.ts
@@ -51,6 +51,7 @@ export const useDashboardData = () => {
     refreshApiKeyStatus,
     clearAllApiKeys,
     unlock,
+    lock,
     showLockedModal,
     setShowLockedModal
   } = useApiKeys();
@@ -176,6 +177,7 @@ export const useDashboardData = () => {
     clearWatchModeState,
     purgeDatabase,
     unlock,
+    lock,
     authInProgress,
     showLockedModal,
     setShowLockedModal

--- a/src/utils/passkeyAuth.ts
+++ b/src/utils/passkeyAuth.ts
@@ -190,6 +190,11 @@ export class PasskeyService {
     await setItem('passkey_credentials', filtered);
   }
 
+  static resetAuth(): void {
+    this.isAuthenticated = false;
+    this.lastCredentialId = null;
+  }
+
   private static arrayBufferToBase64(buffer: ArrayBuffer): string {
     const bytes = new Uint8Array(buffer);
     let binary = '';


### PR DESCRIPTION
## Summary
- add `lock` function in `useApiKeys` hook
- expose `lock` via `useDashboardData` and `Dashboard`
- allow `SecurityManagement` to trigger locking
- provide `resetAuth` method in `PasskeyService`

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_688a23c8a4448325971abe9c04c8257a