### PR TITLE
Add pairing UI

### DIFF
--- a/src/components/Dashboard.tsx
+++ b/src/components/Dashboard.tsx
@@ -17,6 +17,7 @@ import { FeedActions } from '@/components/FeedActions';
 import { WatchMode } from '@/components/WatchMode';
 import { SelectiveRepositoryLoader } from '@/components/SelectiveRepositoryLoader';
 import { ConnectionManager } from '@/components/ConnectionManager';
+import PairingDialog from '@/components/PairingDialog';
 
 // Hook imports
 import { useDashboardData } from '@/hooks/useDashboardData';
@@ -129,6 +130,7 @@ export const Dashboard: React.FC = () => {
 
   return (
     <div className="min-h-screen bg-card">
+      <PairingDialog />
       {/* Header */}
       <header className="border-b bg-card/50 backdrop-blur-sm sticky top-0 z-40" style={{ borderColor: 'hsl(var(--neo-border))' }}>
         <div className="max-w-7xl mx-auto px-6 py-4">

--- a/src/components/PairingDialog.tsx
+++ b/src/components/PairingDialog.tsx
@@ -1,0 +1,56 @@
+import React, { useState, useEffect } from 'react';
+import { Dialog, DialogContent, DialogHeader, DialogTitle } from '@/components/ui/dialog';
+import { Button } from '@/components/ui/button';
+import { getSocketService } from '@/services/SocketService';
+import { useToast } from '@/hooks/use-toast';
+
+const PairingDialog: React.FC = () => {
+  const [open, setOpen] = useState(false);
+  const [token, setToken] = useState<string | null>(null);
+  const { toast } = useToast();
+
+  useEffect(() => {
+    const svc = getSocketService();
+    const unsubToken = svc.onPairToken(t => {
+      setToken(t);
+      setOpen(true);
+    });
+    const unsubResult = svc.onPairResult(success => {
+      if (success) {
+        toast({ title: 'Pairing successful!' });
+        setOpen(false);
+        setToken(null);
+      } else {
+        toast({ title: 'Pairing denied', variant: 'destructive' });
+      }
+    });
+    return () => {
+      unsubToken();
+      unsubResult();
+    };
+  }, [toast]);
+
+  if (!token) return null;
+
+  const approveUrl = `http://${window.location.hostname}:3001/pairings/${token}/approve?secret=secret`;
+
+  return (
+    <Dialog open={open} onOpenChange={setOpen}>
+      <DialogContent className="neo-card space-y-4">
+        <DialogHeader>
+          <DialogTitle>Pair with Server</DialogTitle>
+        </DialogHeader>
+        <div className="space-y-2 text-sm">
+          <p className="font-semibold">Approve this pairing using:</p>
+          <pre className="p-2 bg-muted rounded-md overflow-auto text-xs">{`curl -X POST ${approveUrl}`}</pre>
+          <p>or open the URL above in your browser.</p>
+        </div>
+        <div className="flex justify-end">
+          <Button onClick={() => setOpen(false)} className="neo-button-secondary">Close</Button>
+        </div>
+      </DialogContent>
+    </Dialog>
+  );
+};
+
+export default PairingDialog;


### PR DESCRIPTION
## Summary
- add a pairing dialog component
- expose pair events in SocketService and show dialog in dashboard

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_688a38149f648325b6413b5ce5b3cd80