### PR TITLE
Enhance repo fetching

### DIFF
--- a/server/__tests__/github.test.ts
+++ b/server/__tests__/github.test.ts
@@ -1,5 +1,26 @@
-import { describe, it, expect } from 'vitest';
-import { __test } from '../github.ts';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+const listAuth = vi.fn();
+const listUser = vi.fn();
+const listOrg = vi.fn();
+const getUser = vi.fn();
+
+vi.mock('@octokit/rest', () => ({
+  Octokit: vi.fn().mockImplementation(() => ({
+    rest: {
+      repos: {
+        listForAuthenticatedUser: listAuth,
+        listForUser: listUser,
+        listForOrg: listOrg
+      },
+      users: {
+        getByUsername: getUser
+      }
+    }
+  }))
+}));
+
+import { createGitHubService, __test } from '../github.ts';
 
 const { strayBranchCache, cleanupStrayCache, STRAY_CACHE_TTL } = __test;
 
@@ -16,5 +37,67 @@ describe('strayBranchCache cleanup', () => {
     strayBranchCache.set('o/r', { branches: ['b'], timestamp: Date.now() });
     cleanupStrayCache();
     expect(strayBranchCache.size).toBe(1);
+  });
+});
+
+describe('fetchRepositories', () => {
+  beforeEach(() => {
+    listAuth.mockReset();
+    listUser.mockReset();
+    listOrg.mockReset();
+    getUser.mockReset();
+  });
+
+  it('uses authenticated user when no owner specified', async () => {
+    listAuth.mockResolvedValue({
+      data: [
+        {
+          id: 1,
+          name: 'repo',
+          owner: { login: 'me' },
+          updated_at: '2020-01-01T00:00:00Z'
+        }
+      ]
+    });
+    const svc = createGitHubService('t');
+    const repos = await svc.fetchRepositories({ visibility: 'public', affiliation: 'owner' });
+    expect(listAuth).toHaveBeenCalledWith({ visibility: 'public', affiliation: 'owner', per_page: 100 });
+    expect(repos[0]).toMatchObject({ id: '1', owner: 'me' });
+  });
+
+  it('uses listForUser when owner is a user', async () => {
+    getUser.mockResolvedValue({ data: { type: 'User' } });
+    listUser.mockResolvedValue({
+      data: [
+        {
+          id: 2,
+          name: 'repo',
+          owner: { login: 'bob' },
+          updated_at: '2020-01-02T00:00:00Z'
+        }
+      ]
+    });
+    const svc = createGitHubService('t');
+    const repos = await svc.fetchRepositories({ owner: 'bob' });
+    expect(listUser).toHaveBeenCalledWith({ username: 'bob', type: 'all', per_page: 100 });
+    expect(repos[0]).toMatchObject({ id: '2', owner: 'bob' });
+  });
+
+  it('uses listForOrg when owner is an organization', async () => {
+    getUser.mockResolvedValue({ data: { type: 'Organization' } });
+    listOrg.mockResolvedValue({
+      data: [
+        {
+          id: 3,
+          name: 'repo',
+          owner: { login: 'org' },
+          updated_at: '2020-01-03T00:00:00Z'
+        }
+      ]
+    });
+    const svc = createGitHubService('t');
+    const repos = await svc.fetchRepositories({ owner: 'org' });
+    expect(listOrg).toHaveBeenCalledWith({ org: 'org', type: 'all', per_page: 100 });
+    expect(repos[0]).toMatchObject({ id: '3', owner: 'org' });
   });
 });

--- a/server/socketHandlers.ts
+++ b/server/socketHandlers.ts
@@ -114,7 +114,11 @@ io.on('connection', (socket: Socket) => {
     if (!requirePaired(s, cb)) return;
     try {
       const svc = createGitHubService(params.token);
-      const repos = await svc.fetchRepositories(params.owner || '');
+      const repos = await svc.fetchRepositories({
+        owner: params.owner || '',
+        visibility: params.visibility,
+        affiliation: params.affiliation
+      });
       cb({ ok: true, data: repos });
     } catch (err) {
       cb({ ok: false, error: err.message });
@@ -126,7 +130,11 @@ io.on('connection', (socket: Socket) => {
     if (!requirePaired(s, cb)) return;
     try {
       const svc = createGitHubService(params.token);
-      const repos = await svc.fetchRepositories(params.owner || '');
+      const repos = await svc.fetchRepositories({
+        owner: params.owner || '',
+        visibility: params.visibility,
+        affiliation: params.affiliation
+      });
       cb({ ok: true, data: repos });
     } catch (err) {
       cb({ ok: false, error: err.message });

--- a/src/__tests__/GitHubService.test.ts
+++ b/src/__tests__/GitHubService.test.ts
@@ -46,7 +46,9 @@ describe('GitHubService', () => {
     const res = await service.fetchRepositories('o');
     expect(socketService.request).toHaveBeenCalledWith('fetchRepos', {
       token: 'token',
-      owner: 'o'
+      owner: 'o',
+      visibility: 'all',
+      affiliation: 'owner,collaborator,organization_member'
     });
     expect(res).toEqual(['repo']);
   });
@@ -56,7 +58,9 @@ describe('GitHubService', () => {
     const res = await service.fetchRepositoriesByKey('o');
     expect(socketService.request).toHaveBeenCalledWith('fetchReposByKey', {
       token: 'token',
-      owner: 'o'
+      owner: 'o',
+      visibility: 'all',
+      affiliation: 'owner,collaborator,organization_member'
     });
     expect(res).toEqual(['repo']);
   });

--- a/src/components/GitHubService.tsx
+++ b/src/components/GitHubService.tsx
@@ -11,12 +11,20 @@ export class GitHubService {
     });
   }
 
-  fetchRepositories(owner: string): Promise<Repository[]> {
-    return this.emit('fetchRepos', { owner });
+  fetchRepositories(
+    owner: string,
+    visibility = 'all',
+    affiliation = 'owner,collaborator,organization_member'
+  ): Promise<Repository[]> {
+    return this.emit('fetchRepos', { owner, visibility, affiliation });
   }
 
-  fetchRepositoriesByKey(owner: string): Promise<Repository[]> {
-    return this.emit('fetchReposByKey', { owner });
+  fetchRepositoriesByKey(
+    owner: string,
+    visibility = 'all',
+    affiliation = 'owner,collaborator,organization_member'
+  ): Promise<Repository[]> {
+    return this.emit('fetchReposByKey', { owner, visibility, affiliation });
   }
 
   fetchPullRequests(owner: string, repo: string): Promise<any[]> {

--- a/src/services/SocketService.ts
+++ b/src/services/SocketService.ts
@@ -278,12 +278,22 @@ export class SocketService {
   }
 
   // GitHub Requests
-  async fetchRepositories(token: string, owner: string): Promise<any> {
-    return this.request('fetchRepos', { token, owner });
+  async fetchRepositories(
+    token: string,
+    owner: string,
+    visibility = 'all',
+    affiliation = 'owner,collaborator,organization_member'
+  ): Promise<any> {
+    return this.request('fetchRepos', { token, owner, visibility, affiliation });
   }
 
-  async fetchRepositoriesByKey(token: string, owner: string): Promise<any> {
-    return this.request('fetchReposByKey', { token, owner });
+  async fetchRepositoriesByKey(
+    token: string,
+    owner: string,
+    visibility = 'all',
+    affiliation = 'owner,collaborator,organization_member'
+  ): Promise<any> {
+    return this.request('fetchReposByKey', { token, owner, visibility, affiliation });
   }
 
   async fetchPullRequests(token: string, owner: string, repo: string): Promise<any> {


### PR DESCRIPTION
## Summary
- handle repo owner type when listing repositories
- support visibility/affiliation options via socket
- update GitHub service for new parameters
- extend related tests

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_688a35c768a48325bcae5b668242802f