### PR TITLE
Improve debug logging

### DIFF
--- a/server/index.ts
+++ b/server/index.ts
@@ -9,7 +9,9 @@ import { fileURLToPath } from 'url';
 
 export async function startServer(port: number = Number(process.env.PORT) || 3001) {
   logger.debug('server', 'Starting server', { port });
+  logger.debug('server', 'Waiting for config load');
   await loadPromise;
+  logger.debug('server', 'Config loaded');
   const app = express();
   const corsOptions = {
     origin: '*',
@@ -36,6 +38,7 @@ export async function startServer(port: number = Number(process.env.PORT) || 300
   });
 
   app.get('/logs', (_req, res) => {
+    logger.debug('server', 'GET /logs');
     res.setHeader('Access-Control-Allow-Origin', '*');
     res.json({ logs: logger.getLogs() });
   });
@@ -45,6 +48,7 @@ export async function startServer(port: number = Number(process.env.PORT) || 300
 
   logger.debug('server', 'Starting HTTP server listen', { port });
   httpServer.listen(port, () => {
+    logger.debug('server', 'HTTP server listening', { port });
     logger.info(`Server listening on ${port}`);
   });
 

--- a/src/hooks/useLogger.ts
+++ b/src/hooks/useLogger.ts
@@ -1,5 +1,6 @@
 import { useState, useCallback, useEffect } from 'react';
 import { useGlobalConfig } from './useGlobalConfig';
+import { getSocketService } from '@/services/SocketService';
 
 export interface LogEntry {
   id: string;
@@ -96,6 +97,20 @@ export const useLogger = (
     addLog('info', 'system', 'Logger initialized');
     addLog('info', 'system', `Log level set to: ${logLevel}`);
   }, [addLog, logLevel]);
+
+  useEffect(() => {
+    const svc = getSocketService();
+    const offConnect = svc.onConnect(() =>
+      addLog('debug', 'socket', 'connected')
+    );
+    const offDisconnect = svc.onDisconnect(() =>
+      addLog('debug', 'socket', 'disconnected')
+    );
+    return () => {
+      offConnect();
+      offDisconnect();
+    };
+  }, [addLog]);
 
   const logInfo = useCallback(
     (category: string, message: string, details?: any) => {

--- a/src/services/SocketService.ts
+++ b/src/services/SocketService.ts
@@ -79,6 +79,10 @@ export class SocketService {
 
     while (this.connectionAttempts <= this.maxRetries) {
       try {
+        this.logger.logDebug('socket', 'attempting connection', {
+          attempt: this.connectionAttempts + 1,
+          url: socketUrl
+        });
         const useReal = import.meta.env.VITE_USE_REAL_SOCKET === 'true';
         this.socket = useReal
           ? new RealSocket(socketUrl)
@@ -401,6 +405,7 @@ export class SocketService {
 
   disconnect(): void {
     if (this.socket) {
+      this.logger.logDebug('socket', 'disconnect called');
       this.socket.disconnect();
       this.logger.logInfo('socket', 'Socket disconnected');
     }
@@ -413,6 +418,7 @@ export class SocketService {
   }
 
   reconnect(): void {
+    this.logger.logDebug('socket', 'reconnect called');
     this.initialize(this.address, this.port, this.maxRetries);
   }
 }


### PR DESCRIPTION
## Summary
- add more server debug logs
- log connection events in client via `useLogger`
- trace socket connection attempts
- log when sockets disconnect or reconnect

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_688bcd3d9f04832590000ea55707d412