### PR TITLE
Fix tab text color in themes

### DIFF
--- a/src/index.css
+++ b/src/index.css
@@ -152,6 +152,11 @@
   .neo-card {
     @apply bg-card border-4 border-foreground shadow-[8px_8px_0px_0px_hsl(var(--foreground)/0.5)];
   }
+
+  /* Ensure text color matches theme when a neo-card is used as an active TabsTrigger */
+  .neo-card[data-state="active"] {
+    @apply text-foreground;
+  }
   
   .neo-card.neo-yellow { @apply bg-[hsl(var(--neo-yellow))] text-black border-foreground; }
   .neo-card.neo-pink { @apply bg-[hsl(var(--neo-pink))] text-black border-foreground; }


### PR DESCRIPTION
## Summary
- ensure `neo-card` updates text color when used as an active TabsTrigger

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_688bd6ee7af883258b5a5bc6cfcf3a45