### PR TITLE
Implement config defaults for SocketService

### DIFF
--- a/src/__tests__/SocketService.test.ts
+++ b/src/__tests__/SocketService.test.ts
@@ -47,4 +47,23 @@ describe('SocketService initialization', () => {
     expect(ok).toBe(false);
     expect(connectMock).toHaveBeenCalledTimes(3);
   });
+
+  it('uses defaults from config supplier when params omitted', async () => {
+    const { SocketService } = await import('../services/SocketService.ts');
+    const { logger } = await import('../services/Logger');
+    const debugSpy = vi.spyOn(logger, 'logDebug').mockImplementation(() => {});
+    const svc = new SocketService();
+    svc.setConfigSupplier(() => ({
+      socketServerAddress: 'cfg.host',
+      socketServerPort: 9876,
+      socketMaxRetries: 0
+    }));
+    svc.initialize();
+    expect(debugSpy).toHaveBeenCalledWith(
+      'socket',
+      'attempting connection',
+      expect.objectContaining({ url: 'http://cfg.host:9876' })
+    );
+    svc.disconnect();
+  });
 });

--- a/src/services/SocketService.ts
+++ b/src/services/SocketService.ts
@@ -70,11 +70,12 @@ export class SocketService {
     return `client_${Date.now()}_${Math.random().toString(36).substr(2, 9)}`;
   }
 
-  initialize(address: string = 'localhost', port: number = 8080, maxRetries: number = 5): boolean {
-    this.address = address;
-    this.port = port;
-    this.maxRetries = maxRetries;
-    const socketUrl = `http://${address}:${port}`;
+  initialize(address?: string, port?: number, maxRetries?: number): boolean {
+    const cfg = this.configSupplier ? this.configSupplier() : null;
+    this.address = address ?? cfg?.socketServerAddress ?? 'localhost';
+    this.port = port ?? cfg?.socketServerPort ?? 8080;
+    this.maxRetries = maxRetries ?? cfg?.socketMaxRetries ?? 5;
+    const socketUrl = `http://${this.address}:${this.port}`;
     this.connectionAttempts = 0;
 
     while (this.connectionAttempts <= this.maxRetries) {
@@ -83,7 +84,7 @@ export class SocketService {
           attempt: this.connectionAttempts + 1,
           url: socketUrl
         });
-        const useReal = import.meta.env.VITE_USE_REAL_SOCKET === 'true';
+        const useReal = (import.meta as any).env?.VITE_USE_REAL_SOCKET === 'true';
         this.socket = useReal
           ? new RealSocket(socketUrl)
           : new BasicSocket();


### PR DESCRIPTION
## Summary
- let `SocketService.initialize()` fall back to global config
- handle absent `import.meta.env` when choosing socket implementation
- test defaults from config supplier

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_688bdaccb8988325bd136ae22525bda5