### PR TITLE
feat: configure socket defaults

### DIFF
--- a/src/hooks/useGlobalConfig.ts
+++ b/src/hooks/useGlobalConfig.ts
@@ -24,7 +24,8 @@ const getDefaultConfig = (): GlobalConfig => ({
   serverCheckInterval: 30000, // 30 seconds
   refreshInterval: 30000,
   socketServerAddress: 'localhost',
-  socketServerPort: 3001,
+  // Default socket server port for local development
+  socketServerPort: 8080,
   socketMaxRetries: 5,
   logLevel: 'info',
   darkMode: true,

--- a/src/types/dashboard.ts
+++ b/src/types/dashboard.ts
@@ -173,11 +173,11 @@ export interface GlobalConfig {
   /** Archive already closed PRs when fetching */
   autoArchiveClosed: boolean;
   refreshInterval: number;
-  /** Socket server hostname or IP */
+  /** Socket server hostname or IP (defaults to 'localhost') */
   socketServerAddress: string;
-  /** Socket server port */
+  /** Socket server port (defaults to 8080) */
   socketServerPort: number;
-  /** Socket reconnection attempts */
+  /** Socket reconnection attempts (defaults to 5) */
   socketMaxRetries: number;
   /** Current socket connection status */
   socketConnected: boolean;


### PR DESCRIPTION
## Summary
- document socket server settings in global config
- default socket server to localhost:8080 with 5 retry attempts

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689bd0681fdc8325bfa7a1c428e9981b