### PR TITLE
test: add webhook failure cases

### DIFF
--- a/server/__tests__/webhooks.test.ts
+++ b/server/__tests__/webhooks.test.ts
@@ -1,8 +1,9 @@
-import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
 import fs from 'fs';
 import path from 'path';
 import os from 'os';
 import { WebhookService, type StoredWebhook } from '../webhooks.ts';
+import { logger } from '../logger.ts';
 
 let tmpDir: string;
 let storagePath: string;
@@ -48,5 +49,81 @@ describe('WebhookService storage', () => {
     await WebhookService.deleteWebhook('1');
     const empty = await WebhookService.getWebhooks();
     expect(empty).toEqual([]);
+  });
+});
+
+describe('WebhookService triggerWebhook', () => {
+  const makeHook = (id: string): StoredWebhook => ({
+    id,
+    name: 'test',
+    url: 'http://example.com',
+    secret: 's',
+    events: ['a'],
+    active: true,
+    created: new Date().toISOString()
+  });
+
+  const payload = {
+    event: 'a',
+    repository: 'r',
+    timestamp: new Date().toISOString(),
+    data: {}
+  };
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+    vi.restoreAllMocks();
+  });
+
+  it('updates lastTriggered only on successful calls', async () => {
+    const hook = makeHook('s1');
+    await WebhookService.saveWebhook(hook);
+
+    const fetchMock = vi.fn().mockResolvedValue({ ok: true, status: 200, statusText: 'OK' });
+    vi.stubGlobal('fetch', fetchMock);
+
+    const res = await WebhookService.triggerWebhook(hook, payload);
+    expect(res).toEqual({ success: true });
+
+    const stored = await WebhookService.getWebhooks();
+    expect(stored[0].lastTriggered).toBeDefined();
+
+    await WebhookService.deleteWebhook(hook.id);
+  });
+
+  it('returns error when fetch responds non-200', async () => {
+    const hook = makeHook('f1');
+    await WebhookService.saveWebhook(hook);
+
+    const fetchMock = vi.fn().mockResolvedValue({ ok: false, status: 500, statusText: 'boom' });
+    vi.stubGlobal('fetch', fetchMock);
+    const logSpy = vi.spyOn(logger, 'error');
+
+    const res = await WebhookService.triggerWebhook(hook, payload);
+    expect(res).toEqual({ success: false, error: 'HTTP 500: boom' });
+    expect(logSpy).toHaveBeenCalled();
+
+    const stored = await WebhookService.getWebhooks();
+    expect(stored[0].lastTriggered).toBeUndefined();
+
+    await WebhookService.deleteWebhook(hook.id);
+  });
+
+  it('returns error when fetch rejects', async () => {
+    const hook = makeHook('f2');
+    await WebhookService.saveWebhook(hook);
+
+    const fetchMock = vi.fn().mockRejectedValue(new Error('net fail'));
+    vi.stubGlobal('fetch', fetchMock);
+    const logSpy = vi.spyOn(logger, 'error');
+
+    const res = await WebhookService.triggerWebhook(hook, payload);
+    expect(res).toEqual({ success: false, error: 'net fail' });
+    expect(logSpy).toHaveBeenCalled();
+
+    const stored = await WebhookService.getWebhooks();
+    expect(stored[0].lastTriggered).toBeUndefined();
+
+    await WebhookService.deleteWebhook(hook.id);
   });
 });


### PR DESCRIPTION
## Summary
- add WebhookService triggerWebhook tests for success and failures
- ensure errors logged and lastTriggered updates only on success

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689beff920e483259bf57e02f5499438