### PR TITLE
feat: forward allowed branch patterns to deleteBranch

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,8 +109,9 @@ After a client pairs with the server it should emit a `syncConfig` Socket.IO
 message containing its configuration (for example a list of protected branch
 patterns). The server stores this data per client in `server/config.json` and
 uses the settings when handling actions such as `fetchStrayBranches` and
-`deleteBranch`. The file persists across restarts so important settings remain
-available.
+`deleteBranch`. Deletion requests may also include their own `protectedPatterns`
+and `allowedPatterns` arrays to further control which branches can be removed.
+The file persists across restarts so important settings remain available.
 
 ## Running the server and UI together
 

--- a/src/__tests__/GitHubService.test.ts
+++ b/src/__tests__/GitHubService.test.ts
@@ -52,4 +52,18 @@ describe('GitHubService', () => {
     });
     expect(res).toEqual(['repo']);
   });
+
+  it('emits deleteBranch event with patterns', async () => {
+    (socketService.request as any).mockResolvedValue({ ok: true });
+    const res = await service.deleteBranch('o', 'r', 'b', ['p'], ['a']);
+    expect(socketService.request).toHaveBeenCalledWith('deleteBranch', {
+      token: 'token',
+      owner: 'o',
+      repo: 'r',
+      branch: 'b',
+      protectedPatterns: ['p'],
+      allowedPatterns: ['a']
+    });
+    expect(res).toEqual({ ok: true });
+  });
 });

--- a/src/__tests__/SocketService.test.ts
+++ b/src/__tests__/SocketService.test.ts
@@ -69,3 +69,25 @@ describe('SocketService initialization', () => {
     svc.disconnect();
   });
 });
+
+describe('deleteBranch', () => {
+  it('forwards protected and allowed patterns to the server', async () => {
+    const { SocketService } = await import('../services/SocketService.ts');
+    const svc = new SocketService();
+    const reqSpy = vi
+      .spyOn(svc as any, 'request')
+      .mockResolvedValue({} as any);
+    await svc.deleteBranch('t', 'o', 'r', 'b', ['p'], ['a']);
+    expect(reqSpy).toHaveBeenCalledWith(
+      'deleteBranch',
+      expect.objectContaining({
+        token: 't',
+        owner: 'o',
+        repo: 'r',
+        branch: 'b',
+        protectedPatterns: ['p'],
+        allowedPatterns: ['a']
+      })
+    );
+  });
+});

--- a/src/components/GitHubService.tsx
+++ b/src/components/GitHubService.tsx
@@ -35,9 +35,16 @@ export class GitHubService {
     owner: string,
     repo: string,
     branch: string,
-    protectedPatterns: string[] = []
+    protectedPatterns: string[] = [],
+    allowedPatterns: string[] = []
   ): Promise<boolean> {
-    return this.emit('deleteBranch', { owner, repo, branch, protectedPatterns });
+    return this.emit('deleteBranch', {
+      owner,
+      repo,
+      branch,
+      protectedPatterns,
+      allowedPatterns
+    });
   }
 
   fetchStrayBranches(owner: string, repo: string): Promise<string[]> {

--- a/src/services/SocketService.ts
+++ b/src/services/SocketService.ts
@@ -330,9 +330,17 @@ export class SocketService {
     owner: string,
     repo: string,
     branch: string,
-    protectedPatterns: string[] = []
+    protectedPatterns: string[] = [],
+    allowedPatterns: string[] = []
   ): Promise<any> {
-    return this.request('deleteBranch', { token, owner, repo, branch, protectedPatterns });
+    return this.request('deleteBranch', {
+      token,
+      owner,
+      repo,
+      branch,
+      protectedPatterns,
+      allowedPatterns
+    });
   }
 
   async fetchStrayBranches(token: string, owner: string, repo: string): Promise<any> {


### PR DESCRIPTION
## Summary
- allow `SocketService.deleteBranch` and `GitHubService.deleteBranch` to send `allowedPatterns`
- document `allowedPatterns` option in README
- test that both `protectedPatterns` and `allowedPatterns` are forwarded to the server

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_689beff9511083258e6b034bff7a10a1