### PR TITLE
refactor: unify repo fetching

### DIFF
--- a/server/__tests__/socketHandlers.test.ts
+++ b/server/__tests__/socketHandlers.test.ts
@@ -95,6 +95,11 @@ describe('socket handlers', () => {
       client.emit('fetchRepos', { token: 't', owner: '' }, resolve);
     });
     expect(resp2).toEqual({ ok: true, data: ['repo'] });
+
+    const resp3 = await new Promise<any>(resolve => {
+      client.emit('fetchReposByKey', { token: 't', owner: '' }, resolve);
+    });
+    expect(resp3).toEqual({ ok: true, data: ['repo'] });
   });
 
   it('honours synced protected branches', async () => {


### PR DESCRIPTION
## Summary
- DRY up repository fetch logic with new handleFetchRepos helper
- Alias `fetchRepos` and `fetchReposByKey` events to shared handler
- Test aliasing to ensure both events return repositories

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689bf151daec8325af2476cc9d3245b3