### PR TITLE
Handle non-OK update responses

### DIFF
--- a/src/__tests__/updateChecker.test.ts
+++ b/src/__tests__/updateChecker.test.ts
@@ -14,6 +14,7 @@ describe('checkUserscriptUpdates', () => {
 
   it('returns hasUpdate true when newer version available', async () => {
     const fetchMock = vi.fn().mockResolvedValue({
+      ok: true,
       json: async () => ({ tag_name: 'v1.1.0' })
     });
     vi.stubGlobal('fetch', fetchMock);
@@ -25,11 +26,26 @@ describe('checkUserscriptUpdates', () => {
 
   it('returns hasUpdate false when up to date', async () => {
     const fetchMock = vi.fn().mockResolvedValue({
+      ok: true,
       json: async () => ({ tag_name: 'v1.0.0' })
     });
     vi.stubGlobal('fetch', fetchMock);
 
     const result = await checkUserscriptUpdates();
     expect(result).toEqual({ hasUpdate: false });
+  });
+
+  it('returns hasUpdate false when response not ok', async () => {
+    const jsonMock = vi.fn();
+    const fetchMock = vi.fn().mockResolvedValue({
+      ok: false,
+      status: 500,
+      json: jsonMock
+    });
+    vi.stubGlobal('fetch', fetchMock);
+
+    const result = await checkUserscriptUpdates();
+    expect(result).toEqual({ hasUpdate: false });
+    expect(jsonMock).not.toHaveBeenCalled();
   });
 });

--- a/src/utils/updateChecker.ts
+++ b/src/utils/updateChecker.ts
@@ -11,6 +11,9 @@ export interface UpdateCheckResult {
 export async function checkUserscriptUpdates(): Promise<UpdateCheckResult> {
   try {
     const response = await fetch(UPDATE_API);
+    if (!response.ok) {
+      throw new Error(`Failed to fetch latest release: ${response.status}`);
+    }
     const data = await response.json();
     const latestVersion = (data.tag_name || data.version || '').replace(/^v/, '');
     const currentVersion: string | undefined = (globalThis as any).GM_info?.script?.version;


### PR DESCRIPTION
## Summary
- handle non-OK responses before parsing update JSON
- test update checker for non-OK responses

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689bf6c10a44832589186cca0319c687