### PR TITLE
feat: cap logs and add clear endpoint

### DIFF
--- a/server/__tests__/logger.test.ts
+++ b/server/__tests__/logger.test.ts
@@ -1,0 +1,24 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import { logger, MAX_LOGS } from '../logger.ts';
+
+describe('logger ring buffer', () => {
+  beforeEach(() => {
+    logger.clearLogs();
+  });
+
+  it('caps logs at MAX_LOGS entries', () => {
+    for (let i = 0; i < MAX_LOGS + 100; i++) {
+      console.log(`log ${i}`);
+    }
+    const logs = logger.getLogs();
+    expect(logs.length).toBe(MAX_LOGS);
+    expect(logs[0].message).toContain(`log 100`);
+  });
+
+  it('clears logs', () => {
+    console.log('hello');
+    expect(logger.getLogs().length).toBe(1);
+    logger.clearLogs();
+    expect(logger.getLogs().length).toBe(0);
+  });
+});

--- a/server/index.ts
+++ b/server/index.ts
@@ -50,6 +50,13 @@ export async function startServer(port: number = Number(process.env.PORT) || 300
     res.json({ logs: logger.getLogs() });
   });
 
+  app.delete('/logs', (_req, res) => {
+    logger.debug('server', 'DELETE /logs');
+    logger.clearLogs();
+    res.setHeader('Access-Control-Allow-Origin', '*');
+    res.status(204).send();
+  });
+
   logger.debug('server', 'Registering socket handlers');
   const cleanupTimer = registerSocketHandlers(io, app);
   httpServer.on('close', () => {

--- a/server/logger.ts
+++ b/server/logger.ts
@@ -8,14 +8,25 @@ export type LogEntry = {
 };
 
 export const logEmitter = new EventEmitter();
+
+export const MAX_LOGS = 1000;
 const logs: LogEntry[] = [];
 
 function addLog(level: LogEntry['level'], args: unknown[]) {
-  const message = args.map(a => (typeof a === 'string' ? a : JSON.stringify(a))).join(' ');
+  const message = args
+    .map(a => (typeof a === 'string' ? a : JSON.stringify(a)))
+    .join(' ');
   const id = Date.now().toString(36) + Math.random().toString(36).slice(2, 8);
   const entry = { id, timestamp: new Date(), level, message };
   logs.push(entry);
+  if (logs.length > MAX_LOGS) {
+    logs.shift();
+  }
   logEmitter.emit('log', entry);
+}
+
+function clearLogs() {
+  logs.length = 0;
 }
 
 export const logger = {
@@ -35,7 +46,8 @@ export const logger = {
     addLog('debug', args);
     console.debug('[debug]', ...args);
   },
-  getLogs: () => logs
+  getLogs: () => logs,
+  clearLogs
 };
 
 export function onLog(cb: (entry: LogEntry) => void): () => void {

--- a/src/hooks/useLogger.ts
+++ b/src/hooks/useLogger.ts
@@ -162,7 +162,11 @@ export const useLogger = (
 
   const clearLogs = useCallback(() => {
     setLogs([]);
-  }, []);
+    const url = `http://${globalConfig.socketServerAddress}:${globalConfig.socketServerPort}/logs`;
+    fetch(url, { method: 'DELETE' }).catch(err => {
+      addLog('error', 'logger', 'Failed to clear server logs', err);
+    });
+  }, [addLog, globalConfig.socketServerAddress, globalConfig.socketServerPort]);
 
   const fetchServerLogs = useCallback(async () => {
     try {


### PR DESCRIPTION
## Summary
- store server logs in a ring buffer capped at 1000 and add a `clearLogs` helper
- expose `DELETE /logs` endpoint and hook client to clear server logs
- add tests for log truncation and clearing

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689bf98d5adc832586831ea1b29d2499