### PR TITLE
Handle non-OK responses in update checker

### DIFF
--- a/src/__tests__/updateChecker.test.ts
+++ b/src/__tests__/updateChecker.test.ts
@@ -35,7 +35,7 @@ describe('checkUserscriptUpdates', () => {
     expect(result).toEqual({ hasUpdate: false });
   });
 
-  it('returns hasUpdate false when response not ok', async () => {
+  it('returns error when response not ok', async () => {
     const jsonMock = vi.fn();
     const fetchMock = vi.fn().mockResolvedValue({
       ok: false,
@@ -45,7 +45,7 @@ describe('checkUserscriptUpdates', () => {
     vi.stubGlobal('fetch', fetchMock);
 
     const result = await checkUserscriptUpdates();
-    expect(result).toEqual({ hasUpdate: false });
+    expect(result).toEqual({ hasUpdate: false, error: 'Failed to fetch latest release: 500' });
     expect(jsonMock).not.toHaveBeenCalled();
   });
 });

--- a/src/utils/updateChecker.ts
+++ b/src/utils/updateChecker.ts
@@ -3,6 +3,7 @@ export const UPDATE_API = 'https://api.github.com/repos/lovable-dev/codex-github
 export interface UpdateCheckResult {
   hasUpdate: boolean;
   latestVersion?: string;
+  error?: string;
 }
 
 /**
@@ -12,7 +13,7 @@ export async function checkUserscriptUpdates(): Promise<UpdateCheckResult> {
   try {
     const response = await fetch(UPDATE_API);
     if (!response.ok) {
-      throw new Error(`Failed to fetch latest release: ${response.status}`);
+      return { hasUpdate: false, error: `Failed to fetch latest release: ${response.status}` };
     }
     const data = await response.json();
     const latestVersion = (data.tag_name || data.version || '').replace(/^v/, '');
@@ -21,8 +22,8 @@ export async function checkUserscriptUpdates(): Promise<UpdateCheckResult> {
     if (latestVersion && currentVersion && isVersionGreater(latestVersion, currentVersion)) {
       return { hasUpdate: true, latestVersion };
     }
-  } catch {
-    // ignore network or parsing errors
+  } catch (e) {
+    return { hasUpdate: false, error: e instanceof Error ? e.message : String(e) };
   }
 
   return { hasUpdate: false };


### PR DESCRIPTION
## Summary
- include error field in update result and handle failed fetch responses
- cover non-OK responses in update checker tests

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689c85d97424832591c938176fc493cd