### PR TITLE
Encrypt webhook secrets

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,7 +94,9 @@ If polling fails repeatedly the server now applies an exponential backoff,
 doubling the interval up to `POLL_MAX_INTERVAL_MS` (default: `300000` ms). The
 backoff factor can be controlled with `POLL_BACKOFF_MULTIPLIER`.
 Webhook configurations are stored in `server/webhooks.json`. Set the
-`WEBHOOK_STORAGE_PATH` variable to change this location.
+`WEBHOOK_STORAGE_PATH` variable to change this location. If
+`WEBHOOK_SECRET_KEY` is provided, webhook secrets are encrypted on disk using
+this key and transparently decrypted when loaded.
 
 When a pull request is opened, closed, merged or a security alert appears,
 socket clients subscribed via the `subscribeRepo` message receive a `repoUpdate`
@@ -131,6 +133,7 @@ npm run dev
 The script builds the server and then starts it on `PORT` (default `3001`) while
 launching the Vite dev server concurrently. You can still customise
 `POLL_INTERVAL_MS`, `CACHE_TTL_MS`, `STRAY_BRANCH_CACHE_TTL_MS`,
-`POLL_MAX_INTERVAL_MS`, `POLL_BACKOFF_MULTIPLIER`, `WEBHOOK_STORAGE_PATH` and `PAIR_SECRET` using environment variables. GitHub
+`POLL_MAX_INTERVAL_MS`, `POLL_BACKOFF_MULTIPLIER`, `WEBHOOK_STORAGE_PATH`,
+`WEBHOOK_SECRET_KEY` and `PAIR_SECRET` using environment variables. GitHub
 Personal Access Tokens can be provided through the UI itself or by setting the
 `GITHUB_TOKEN` environment variable before starting the server.

--- a/server/utils/encryption.ts
+++ b/server/utils/encryption.ts
@@ -1,0 +1,34 @@
+import crypto from 'crypto';
+
+const ALGORITHM = 'aes-256-cbc';
+const PREFIX = 'enc:';
+
+function getKey(): Buffer | null {
+  const secret = process.env.WEBHOOK_SECRET_KEY;
+  if (!secret) return null;
+  // Derive a 32-byte key from the provided string
+  return crypto.createHash('sha256').update(secret).digest();
+}
+
+export function encryptSecret(secret: string): string {
+  const key = getKey();
+  if (!key) return secret;
+  const iv = crypto.randomBytes(16);
+  const cipher = crypto.createCipheriv(ALGORITHM, key, iv);
+  const encrypted = Buffer.concat([cipher.update(secret, 'utf8'), cipher.final()]);
+  return `${PREFIX}${iv.toString('hex')}:${encrypted.toString('hex')}`;
+}
+
+export function decryptSecret(secret: string): string {
+  const key = getKey();
+  if (!key) return secret;
+  if (!secret.startsWith(PREFIX)) return secret;
+  const [ivHex, dataHex] = secret.slice(PREFIX.length).split(':');
+  const iv = Buffer.from(ivHex, 'hex');
+  const decipher = crypto.createDecipheriv(ALGORITHM, key, iv);
+  const decrypted = Buffer.concat([
+    decipher.update(Buffer.from(dataHex, 'hex')),
+    decipher.final()
+  ]);
+  return decrypted.toString('utf8');
+}


### PR DESCRIPTION
## Summary
- encrypt webhook secrets at rest using AES-256-CBC with `WEBHOOK_SECRET_KEY`
- transparently decrypt secrets when loading and triggering webhooks, with automatic migration of plaintext entries
- document `WEBHOOK_SECRET_KEY` variable and expand tests for encrypted storage

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_689c85cd5e58832591f65e113394e4fa