### PR TITLE
feat: deep merge watcher configs

### DIFF
--- a/README.md
+++ b/README.md
@@ -120,7 +120,9 @@ patterns). The server stores this data per client in `server/config.json` and
 uses the settings when handling actions such as `fetchStrayBranches` and
 `deleteBranch`. Deletion requests may also include their own `protectedPatterns`
 and `allowedPatterns` arrays to further control which branches can be removed.
-The file persists across restarts so important settings remain available.
+Configuration updates are deep merged, allowing nested arrays and objects to be
+combined instead of replaced. The file persists across restarts so important
+settings remain available.
 
 ## Running the server and UI together
 

--- a/server/__tests__/config.test.ts
+++ b/server/__tests__/config.test.ts
@@ -45,4 +45,12 @@ describe('client config storage', () => {
     await loadModule();
     expect(mod.getClientConfig('c1')).toEqual({ foo: 'bar' });
   });
+
+  it('deep merges nested config', async () => {
+    await mod.setClientConfig('c1', { nested: { arr: [1], obj: { a: true } } });
+    await mod.setClientConfig('c1', { nested: { arr: [2], obj: { b: true } } });
+    expect(mod.getClientConfig('c1')).toEqual({
+      nested: { arr: [1, 2], obj: { a: true, b: true } }
+    });
+  });
 });

--- a/server/__tests__/watchers.test.ts
+++ b/server/__tests__/watchers.test.ts
@@ -199,6 +199,34 @@ describe('subscribeRepo', () => {
     expect(watcher.token).toBe('t2');
     expect(createGitHubServiceMock).toHaveBeenLastCalledWith('t2');
   });
+
+  it('deep merges nested config values', async () => {
+    eventsMock.mockResolvedValue({ data: [] });
+    alertsMock.mockResolvedValue({ data: [] });
+
+    subscribeRepo(socket, {
+      token: 't',
+      owner: 'o',
+      repo: 'r',
+      config: { nested: { arr: ['a'], obj: { a: 1 } } }
+    });
+    await Promise.resolve();
+    const first = getWatcher('o', 'r')!;
+    while (first.isPolling) {
+      await Promise.resolve();
+    }
+
+    subscribeRepo(socket, {
+      token: 't',
+      owner: 'o',
+      repo: 'r',
+      config: { nested: { arr: ['b'], obj: { b: 2 } } }
+    });
+    const watcher = getWatcher('o', 'r');
+    expect(watcher.config).toEqual({
+      nested: { arr: ['a', 'b'], obj: { a: 1, b: 2 } }
+    });
+  });
 });
 
 describe('cache cleanup', () => {

--- a/server/config.ts
+++ b/server/config.ts
@@ -1,6 +1,7 @@
 import fs from 'fs/promises';
 import path from 'path';
 import type { WatcherConfig } from './watchers.js';
+import { deepMerge } from './utils/deepMerge.js';
 
 const STORAGE_PATH =
   process.env.CONFIG_STORAGE_PATH ||
@@ -35,7 +36,7 @@ export async function setClientConfig(
   clientId: string,
   cfg: WatcherConfig
 ): Promise<void> {
-  configs[clientId] = { ...configs[clientId], ...cfg } as WatcherConfig;
+  configs[clientId] = deepMerge(configs[clientId] || {}, cfg);
   await save();
 }
 

--- a/server/utils/deepMerge.ts
+++ b/server/utils/deepMerge.ts
@@ -1,0 +1,26 @@
+export function deepMerge(target: any, source: any): any {
+  if (Array.isArray(target) && Array.isArray(source)) {
+    const result = [...target];
+    for (const item of source) {
+      if (!result.includes(item)) result.push(item);
+    }
+    return result;
+  }
+  if (isPlainObject(target) && isPlainObject(source)) {
+    const result: Record<string, any> = { ...target };
+    for (const key of Object.keys(source)) {
+      const srcVal = source[key];
+      if (key in result) {
+        result[key] = deepMerge(result[key], srcVal);
+      } else {
+        result[key] = srcVal;
+      }
+    }
+    return result;
+  }
+  return source;
+}
+
+function isPlainObject(value: any): value is Record<string, any> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value);
+}

--- a/server/watchers.ts
+++ b/server/watchers.ts
@@ -3,6 +3,7 @@ import { createGitHubService, RateLimitError } from './github.js';
 import { WebhookService } from './webhooks.js';
 import { logger } from './logger.js';
 import { matchesPattern } from './shared/matchesPattern.js';
+import { deepMerge } from './utils/deepMerge.js';
 
 const DEFAULT_INTERVAL = parseInt(process.env.POLL_INTERVAL_MS || '60000', 10);
 const MAX_INTERVAL = parseInt(process.env.POLL_MAX_INTERVAL_MS || '300000', 10);
@@ -105,7 +106,7 @@ export function subscribeRepo(
     isNew = true;
   } else {
     watcher.token = token;
-    watcher.config = { ...watcher.config, ...config };
+    watcher.config = deepMerge(watcher.config, config);
     if (interval && interval !== watcher.baseInterval) {
       clearInterval(watcher.timer);
       watcher.interval = interval;


### PR DESCRIPTION
## Summary
- support deep merging of watcher config updates
- persist nested config using the same deep merge helper
- document and test nested config merge behavior

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68a70ad55ff08325a837f04fbf46f7a3