### PR TITLE
feat: add update checker with ETag caching

### DIFF
--- a/src/__tests__/updateChecker.test.ts
+++ b/src/__tests__/updateChecker.test.ts
@@ -1,0 +1,62 @@
+import { describe, it, expect, vi, afterEach } from 'vitest';
+import { checkForUpdate } from '../utils/updateChecker';
+
+const storage: Record<string, string> = {};
+const mockLocalStorage = {
+  getItem: (k: string) => (k in storage ? storage[k] : null),
+  setItem: (k: string, v: string) => { storage[k] = v; },
+  removeItem: (k: string) => { delete storage[k]; },
+  clear: () => { Object.keys(storage).forEach(k => delete storage[k]); }
+};
+vi.stubGlobal('localStorage', mockLocalStorage);
+
+const originalFetch = global.fetch;
+
+afterEach(() => {
+  global.fetch = originalFetch;
+  mockLocalStorage.clear();
+  vi.useRealTimers();
+});
+
+describe('checkForUpdate', () => {
+  it('aborts when the request times out', async () => {
+    vi.useFakeTimers();
+
+    const fetchMock = vi.fn((_url, options: any) => {
+      const signal: AbortSignal | undefined = options?.signal;
+      return new Promise((_resolve, reject) => {
+        signal?.addEventListener('abort', () => {
+          reject(new DOMException('Aborted', 'AbortError'));
+        });
+      });
+    });
+    global.fetch = fetchMock as any;
+
+    const promise = checkForUpdate('https://example.com/manifest.json', { timeout: 100 });
+    vi.advanceTimersByTime(150);
+    await expect(promise).rejects.toThrow(/aborted/i);
+  });
+
+  it('caches ETag and sends If-None-Match on subsequent requests', async () => {
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValueOnce(
+        new Response(JSON.stringify({ version: '1.0.0' }), {
+          status: 200,
+          headers: { ETag: 'etag-123' }
+        })
+      )
+      .mockResolvedValueOnce(new Response(null, { status: 304 }));
+
+    global.fetch = fetchMock as any;
+
+    const first = await checkForUpdate('https://example.com/manifest.json');
+    expect(first.hasUpdate).toBe(true);
+    expect(localStorage.getItem('update-checker-etag')).toBe('etag-123');
+
+    const second = await checkForUpdate('https://example.com/manifest.json');
+    const headers = fetchMock.mock.calls[1][1]?.headers as any;
+    expect(headers['If-None-Match']).toBe('etag-123');
+    expect(second.hasUpdate).toBe(false);
+  });
+});

--- a/src/utils/updateChecker.ts
+++ b/src/utils/updateChecker.ts
@@ -1,0 +1,65 @@
+export interface UpdateCheckResult {
+  hasUpdate: boolean;
+  version?: string;
+  data?: unknown;
+}
+
+export interface UpdateCheckOptions {
+  timeout?: number;
+  signal?: AbortSignal;
+}
+
+/**
+ * Fetches the update manifest from the provided URL. Uses ETag caching to avoid
+ * re-downloading unchanged manifests. If a request takes longer than the
+ * specified timeout and no AbortSignal is provided, the request will be aborted.
+ */
+export async function checkForUpdate(
+  url: string,
+  { timeout = 5000, signal }: UpdateCheckOptions = {}
+): Promise<UpdateCheckResult> {
+  let controller: AbortController | undefined;
+  let timer: ReturnType<typeof setTimeout> | undefined;
+
+  // Create our own controller if none was provided so we can enforce a timeout
+  if (!signal) {
+    controller = new AbortController();
+    timer = setTimeout(() => controller?.abort(), timeout);
+  }
+
+  const headers: Record<string, string> = {};
+  const cachedEtag = localStorage.getItem('update-checker-etag');
+  if (cachedEtag) {
+    headers['If-None-Match'] = cachedEtag;
+  }
+
+  try {
+    const response = await fetch(url, {
+      headers,
+      signal: signal ?? controller!.signal,
+    });
+
+    // 304 means nothing has changed, no need to parse JSON
+    if (response.status === 304) {
+      return { hasUpdate: false };
+    }
+
+    if (!response.ok) {
+      throw new Error(`Update check failed: ${response.status}`);
+    }
+
+    const data = await response.json();
+    const version = (data as any).version as string | undefined;
+    const etag = response.headers.get('ETag');
+    if (etag) {
+      localStorage.setItem('update-checker-etag', etag);
+    }
+    if (version) {
+      localStorage.setItem('update-checker-version', version);
+    }
+
+    return { hasUpdate: true, version, data };
+  } finally {
+    if (timer) clearTimeout(timer);
+  }
+}


### PR DESCRIPTION
## Summary
- add update checker utility that supports timeouts and ETag caching
- avoid repeated downloads using If-None-Match header and 304 handling
- test abort timeout and ETag cache behavior

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a75677bbc48325bcb3f48cdaa4fbc6